### PR TITLE
Add Playwright e2e coverage and CI workflow for starter

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,134 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  integration-tests:
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    name: Playwright e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: ${{ github.repository == 'imbhargav5/nextbase-nextjs-supabase-starter' }}
+    env:
+      PORT: 3000
+      NODE_ENV: test
+      CI: true
+      TURBO_TELEMETRY_DISABLED: 1
+
+    steps:
+      - name: 'Check if user has write access'
+        uses: 'lannonbr/repo-permission-check-action@2.0.0'
+        with:
+          permission: 'write'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: github.event_name == 'pull_request'
+        name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - if: github.event_name != 'pull_request'
+        name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: 🚂 CI Setup
+        uses: ./.github/actions/ci-setup
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-browsers-v1-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Set up Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase in background
+        run: |
+          cd apps/database
+          supabase start --exclude realtime,imgproxy,studio,edge-runtime &
+          echo "Supabase starting in background..."
+
+      - name: Install Playwright browsers
+        run: |
+          cd apps/web
+          pnpm exec playwright install chromium
+
+      - name: Wait for Supabase to be ready
+        run: |
+          timeout=180
+          counter=0
+          echo "Waiting for Supabase to be ready..."
+          until curl -s http://localhost:54321/rest/v1/ > /dev/null; do
+            if [ $counter -eq $timeout ]; then
+              echo "Timeout waiting for Supabase"
+              exit 1
+            fi
+            counter=$((counter + 1))
+            echo "Waiting... ($counter/$timeout)"
+            sleep 1
+          done
+          echo "Supabase is ready!"
+
+      - name: Wait for Inbucket to be ready
+        run: |
+          timeout=180
+          counter=0
+          echo "Waiting for Inbucket to be ready..."
+          until curl -s http://localhost:54324 > /dev/null; do
+            if [ $counter -eq $timeout ]; then
+              echo "Timeout waiting for Inbucket"
+              exit 1
+            fi
+            counter=$((counter + 1))
+            echo "Waiting... ($counter/$timeout)"
+            sleep 1
+          done
+          echo "Inbucket is ready!"
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Run integration tests
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_on: error
+          retry_on_exit_code: 1
+          command: pnpm run test:e2e
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-failure-report
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
+          retention-days: 30
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
+          retention-days: 30

--- a/apps/web/e2e/_helpers/login-user.helper.ts
+++ b/apps/web/e2e/_helpers/login-user.helper.ts
@@ -1,47 +1,68 @@
-import type { Page } from '@playwright/test';
+import { request, type Page } from '@playwright/test';
 
 const INBUCKET_URL = 'http://localhost:54324';
 
 interface InbucketMessage {
-  id: string;
-  subject: string;
+  ID: string;
+  Created: string;
 }
 
 interface InbucketMessageDetail {
-  body: {
-    text: string;
-    html?: string;
-  };
+  Text: string;
 }
 
 async function getLatestEmailForAddress(emailAddress: string): Promise<InbucketMessageDetail | null> {
   const mailbox = emailAddress.split('@')[0];
-  const messagesUrl = `${INBUCKET_URL}/api/v1/mailbox/${mailbox}`;
+  const requestContext = await request.newContext();
 
-  for (let i = 0; i < 20; i++) {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    const res = await fetch(messagesUrl).catch(() => null);
-    if (!res) continue;
-    const messages: InbucketMessage[] = await res.json().catch(() => []);
-    if (messages.length > 0) {
-      const latest = messages[messages.length - 1];
-      const detailRes = await fetch(`${INBUCKET_URL}/api/v1/mailbox/${mailbox}/${latest.id}`).catch(() => null);
-      if (!detailRes) continue;
-      return detailRes.json().catch(() => null);
+  try {
+    for (let i = 0; i < 20; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const response = await requestContext
+        .get(`${INBUCKET_URL}/api/v1/search?query=${mailbox}&limit=20`)
+        .catch(() => null);
+      if (!response?.ok()) continue;
+
+      const body = (await response.json().catch(() => null)) as
+        | { messages?: InbucketMessage[] }
+        | null;
+      const messages = body?.messages ?? [];
+      if (!messages.length) continue;
+
+      const latest = [...messages].sort(
+        (a, b) => new Date(b.Created).getTime() - new Date(a.Created).getTime()
+      )[0];
+      const detailResponse = await requestContext
+        .get(`${INBUCKET_URL}/api/v1/message/${latest.ID}`)
+        .catch(() => null);
+      if (!detailResponse?.ok()) continue;
+
+      const detail = (await detailResponse.json().catch(() => null)) as
+        | InbucketMessageDetail
+        | null;
+      if (detail?.Text) {
+        return detail;
+      }
     }
+    return null;
+  } finally {
+    await requestContext.dispose();
   }
-  return null;
 }
 
-function extractConfirmationLink(text: string): string | null {
+function extractConfirmationLink(text: string, siteURL: string): string | null {
   const patterns = [
-    /(https?:\/\/localhost[^\s"<]+confirm[^\s"<]+)/i,
-    /(https?:\/\/localhost[^\s"<]+magic[^\s"<]+)/i,
+    /Log In \( (.+) \)/i,
+    /(https?:\/\/127\.0\.0\.1[^\s"<]+)/i,
     /(https?:\/\/localhost[^\s"<]+)/i,
   ];
   for (const pattern of patterns) {
     const match = text.match(pattern);
-    if (match) return match[1];
+    if (!match) continue;
+
+    const link = new URL(match[1]);
+    link.searchParams.set('redirect_to', new URL('/auth/callback', siteURL).toString());
+    return link.toString();
   }
   return null;
 }
@@ -61,7 +82,7 @@ export async function loginUserHelper({
   const emailDetail = await getLatestEmailForAddress(emailAddress);
   if (!emailDetail) throw new Error('No login email received');
 
-  const link = extractConfirmationLink(emailDetail.body.text);
+  const link = extractConfirmationLink(emailDetail.Text, page.url());
   if (!link) throw new Error('Could not find login link in email');
 
   await page.goto(link);

--- a/apps/web/e2e/_helpers/signup.helper.ts
+++ b/apps/web/e2e/_helpers/signup.helper.ts
@@ -1,47 +1,69 @@
-import type { Page } from '@playwright/test';
+import { expect, request, type Page } from '@playwright/test';
 
 const INBUCKET_URL = 'http://localhost:54324';
 
 interface InbucketMessage {
-  id: string;
-  subject: string;
+  ID: string;
+  Created: string;
 }
 
 interface InbucketMessageDetail {
-  body: {
-    text: string;
-    html?: string;
-  };
+  Text: string;
 }
 
 async function getLatestEmailForAddress(emailAddress: string): Promise<InbucketMessageDetail | null> {
   const mailbox = emailAddress.split('@')[0];
-  const messagesUrl = `${INBUCKET_URL}/api/v1/mailbox/${mailbox}`;
+  const requestContext = await request.newContext();
 
-  for (let i = 0; i < 20; i++) {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    const res = await fetch(messagesUrl).catch(() => null);
-    if (!res) continue;
-    const messages: InbucketMessage[] = await res.json().catch(() => []);
-    if (messages.length > 0) {
-      const latest = messages[messages.length - 1];
-      const detailRes = await fetch(`${INBUCKET_URL}/api/v1/mailbox/${mailbox}/${latest.id}`).catch(() => null);
-      if (!detailRes) continue;
-      return detailRes.json().catch(() => null);
+  try {
+    for (let i = 0; i < 20; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const response = await requestContext
+        .get(`${INBUCKET_URL}/api/v1/search?query=${mailbox}&limit=20`)
+        .catch(() => null);
+      if (!response?.ok()) continue;
+
+      const body = (await response.json().catch(() => null)) as
+        | { messages?: InbucketMessage[] }
+        | null;
+      const messages = body?.messages ?? [];
+      if (!messages.length) continue;
+
+      const latest = [...messages].sort(
+        (a, b) => new Date(b.Created).getTime() - new Date(a.Created).getTime()
+      )[0];
+      const detailResponse = await requestContext
+        .get(`${INBUCKET_URL}/api/v1/message/${latest.ID}`)
+        .catch(() => null);
+      if (!detailResponse?.ok()) continue;
+
+      const detail = (await detailResponse.json().catch(() => null)) as
+        | InbucketMessageDetail
+        | null;
+      if (detail?.Text) {
+        return detail;
+      }
     }
+    return null;
+  } finally {
+    await requestContext.dispose();
   }
-  return null;
 }
 
-function extractConfirmationLink(text: string): string | null {
+function extractConfirmationLink(text: string, siteURL: string): string | null {
   const patterns = [
+    /Log In \( (.+) \)/i,
     /Confirm your email address[^"]*"(https?:\/\/[^"]+)"/i,
-    /(https?:\/\/localhost[^\s"<]+confirm[^\s"<]+)/i,
+    /(https?:\/\/127\.0\.0\.1[^\s"<]+)/i,
     /(https?:\/\/localhost[^\s"<]+)/i,
   ];
   for (const pattern of patterns) {
     const match = text.match(pattern);
-    if (match) return match[1];
+    if (!match) continue;
+
+    const link = new URL(match[1]);
+    link.searchParams.set('redirect_to', new URL('/auth/callback', siteURL).toString());
+    return link.toString();
   }
   return null;
 }
@@ -57,11 +79,12 @@ export async function signupUserHelper({
   await page.getByRole('tab', { name: 'Magic Link' }).click();
   await page.getByPlaceholder(/email/i).fill(emailAddress);
   await page.getByRole('button', { name: /send magic link|sign up/i }).click();
+  await expect(page.getByText('Confirmation Link Sent')).toBeVisible();
 
   const emailDetail = await getLatestEmailForAddress(emailAddress);
   if (!emailDetail) throw new Error('No confirmation email received');
 
-  const link = extractConfirmationLink(emailDetail.body.text);
+  const link = extractConfirmationLink(emailDetail.Text, page.url());
   if (!link) throw new Error('Could not find confirmation link in email');
 
   await page.goto(link);

--- a/apps/web/e2e/about.spec.ts
+++ b/apps/web/e2e/about.spec.ts
@@ -1,6 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('about page has heading', async ({ page }) => {
-  await page.goto('/about');
-  await expect(page.locator('h1')).toBeVisible();
-});

--- a/apps/web/e2e/anon/access-to-pages.spec.ts
+++ b/apps/web/e2e/anon/access-to-pages.spec.ts
@@ -1,35 +1,15 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Anonymous user page access', () => {
-  test('can access home page', async ({ page }) => {
-    await page.goto('/');
-    await expect(page).toHaveURL('/');
-    await expect(page.locator('h1')).toBeVisible();
-  });
-
-  test('can access about page', async ({ page }) => {
-    await page.goto('/about');
-    await expect(page).toHaveURL('/about');
-    await expect(page.locator('h1')).toBeVisible();
-  });
-
-  test('can access login page', async ({ page }) => {
-    await page.goto('/login');
-    await expect(page).toHaveURL('/login');
-  });
-
-  test('can access sign-up page', async ({ page }) => {
-    await page.goto('/sign-up');
-    await expect(page).toHaveURL('/sign-up');
-  });
-
+test.describe.parallel('Anonymous user gated page access', () => {
   test('is redirected from dashboard to login', async ({ page }) => {
     await page.goto('/dashboard');
     await expect(page).toHaveURL(/login/, { timeout: 10000 });
+    await expect(page.getByText('Login to NextBase')).toBeVisible();
   });
 
   test('is redirected from private items to login', async ({ page }) => {
     await page.goto('/private-items');
     await expect(page).toHaveURL(/login/, { timeout: 10000 });
+    await expect(page.getByText('Login to NextBase')).toBeVisible();
   });
 });

--- a/apps/web/e2e/anon/public-pages.spec.ts
+++ b/apps/web/e2e/anon/public-pages.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+test.describe.parallel('Anonymous user public pages', () => {
+  test('can access the home page', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page).toHaveURL('/');
+    await expect(
+      page.getByRole('heading', { name: /build your.+saas product.+faster/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /get started/i }).first()
+    ).toBeVisible();
+  });
+
+  test('can access the about page', async ({ page }) => {
+    await page.goto('/about');
+
+    await expect(page).toHaveURL('/about');
+    await expect(
+      page.getByRole('heading', { name: /modern full-stack starter kit/i })
+    ).toBeVisible();
+  });
+
+  test('can access the login page', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(page).toHaveURL('/login');
+    await expect(page.getByText('Login to NextBase')).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Magic Link' })).toBeVisible();
+  });
+
+  test('can access the sign-up page', async ({ page }) => {
+    await page.goto('/sign-up');
+
+    await expect(page).toHaveURL('/sign-up');
+    await expect(page.getByText('Register to NextBase')).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Magic Link' })).toBeVisible();
+  });
+});

--- a/apps/web/e2e/user/access-to-pages.spec.ts
+++ b/apps/web/e2e/user/access-to-pages.spec.ts
@@ -1,19 +1,35 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Logged-in user page access', () => {
+test.describe.parallel('Logged-in user page access', () => {
   test('can access dashboard', async ({ page }) => {
     await page.goto('/dashboard');
     await expect(page).toHaveURL('/dashboard');
-    await expect(page.locator('text=Dashboard')).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Dashboard' })
+    ).toBeVisible();
   });
 
   test('can access private items', async ({ page }) => {
     await page.goto('/private-items');
     await expect(page).toHaveURL('/private-items');
+    await expect(
+      page.getByRole('heading', { name: 'Private Items', level: 1 })
+    ).toBeVisible();
   });
 
   test('can access home page', async ({ page }) => {
     await page.goto('/');
     await expect(page).toHaveURL('/');
+    await expect(
+      page.getByRole('heading', { name: /build your.+saas product.+faster/i })
+    ).toBeVisible();
+  });
+
+  test('can access about page', async ({ page }) => {
+    await page.goto('/about');
+    await expect(page).toHaveURL('/about');
+    await expect(
+      page.getByRole('heading', { name: /modern full-stack starter kit/i })
+    ).toBeVisible();
   });
 });

--- a/apps/web/e2e/user/private-items.spec.ts
+++ b/apps/web/e2e/user/private-items.spec.ts
@@ -5,26 +5,33 @@ test.describe('Private items management', () => {
     await page.goto('/dashboard');
     await page.getByRole('link', { name: /new private item/i }).click();
     await expect(page).toHaveURL('/dashboard/new');
-    await expect(page.locator('text=Create Private Item')).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Create Private Item' })
+    ).toBeVisible();
   });
 
-  test('can create a private item', async ({ page }) => {
+  test('can create a private item and see it in the private items list', async ({
+    page,
+  }) => {
     await page.goto('/dashboard/new');
     const timestamp = Date.now();
     const itemName = `Test Item ${timestamp}`;
+    const itemDescription = `A test description for this item ${timestamp}`;
 
     await page.getByLabel(/name/i).fill(itemName);
-    await page.getByLabel(/description/i).fill('A test description for this item');
+    await page.getByLabel(/description/i).fill(itemDescription);
     await page.getByRole('button', { name: /create private item/i }).click();
 
-    // Should redirect to the item's page
     await expect(page).toHaveURL(/private-item\//, { timeout: 15000 });
     await expect(page.getByText(itemName)).toBeVisible();
-  });
+    await expect(
+      page.locator('p', { hasText: itemDescription })
+    ).toBeVisible();
 
-  test('private items list shows created items', async ({ page }) => {
     await page.goto('/private-items');
-    // Page loads without error
-    await expect(page.locator('main')).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Private Items', level: 1 })
+    ).toBeVisible();
+    await expect(page.getByText(itemName)).toBeVisible();
   });
 });

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,21 +1,67 @@
+import { execSync } from 'node:child_process';
 import { devices, type PlaywrightTestConfig } from '@playwright/test';
 import path from 'path';
 
 const PORT = process.env.PORT || 3000;
 const baseURL = `http://localhost:${PORT}`;
+const isCI = !!process.env.CI;
+
+process.env.PLAYWRIGHT_TEST_BASE_URL ??= `${baseURL}/`;
+
+function parseEnvOutput(output: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of output.split('\n')) {
+    const match = line.match(/^([A-Z_]+)="(.+)"$/);
+    if (match) result[match[1]] = match[2];
+  }
+  return result;
+}
+
+function getWebServerEnv() {
+  const webServerEnv = { ...process.env };
+  const databaseDir = path.resolve(__dirname, '..', 'database');
+
+  try {
+    const statusOutput = execSync('pnpm exec supabase status --output env', {
+      cwd: databaseDir,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const parsed = parseEnvOutput(statusOutput);
+
+    if (!(parsed.API_URL && parsed.PUBLISHABLE_KEY)) {
+      throw new Error('Supabase status is missing API_URL or PUBLISHABLE_KEY');
+    }
+
+    webServerEnv.NEXT_PUBLIC_SUPABASE_URL = `${parsed.API_URL}/`;
+    webServerEnv.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = parsed.PUBLISHABLE_KEY;
+    webServerEnv.NEXT_PUBLIC_SITE_URL = `${baseURL}/`;
+    return webServerEnv;
+  } catch (error) {
+    const err = error as { message?: string };
+    throw new Error(
+      err.message ??
+        'Playwright webServer could not resolve local Supabase settings. Start Supabase with: cd apps/database && pnpm supabase start'
+    );
+  }
+}
+
+const webServerEnv = getWebServerEnv();
 
 const config: PlaywrightTestConfig = {
   workers: 2,
-  timeout: 60 * 1000,
+  timeout: 120 * 1000,
   testDir: path.join(__dirname, 'e2e'),
   retries: 2,
   outputDir: 'test-results/',
-  reporter: process.env.CI ? 'github' : 'list',
+  reporter: isCI ? [['github'], ['html', { open: 'never' }]] : 'list',
   webServer: {
-    command: 'pnpm build && pnpm start',
+    command: isCI ? 'pnpm start' : 'pnpm build && pnpm start',
+    cwd: __dirname,
+    env: webServerEnv,
     url: baseURL,
-    timeout: 180 * 1000,
-    reuseExistingServer: !process.env.CI,
+    timeout: isCI ? 180 * 1000 : 300 * 1000,
+    reuseExistingServer: !isCI,
     stdout: 'pipe',
     stderr: 'pipe',
   },
@@ -27,8 +73,8 @@ const config: PlaywrightTestConfig = {
     trace: 'retain-on-failure',
     navigationTimeout: 30 * 1000,
     actionTimeout: 30 * 1000,
-    video: process.env.CI ? 'retain-on-failure' : 'off',
-    screenshot: process.env.CI ? 'only-on-failure' : 'off',
+    video: isCI ? 'retain-on-failure' : 'off',
+    screenshot: isCI ? 'only-on-failure' : 'off',
   },
   projects: [
     {
@@ -38,6 +84,7 @@ const config: PlaywrightTestConfig = {
     {
       name: 'logged-in-users',
       testMatch: 'user/**/*.spec.ts',
+      grepInvert: /Anonymous user/,
       retries: 0,
       dependencies: ['with-user-setup'],
       use: {
@@ -48,6 +95,7 @@ const config: PlaywrightTestConfig = {
     {
       name: 'anon-users',
       testMatch: 'anon/**/*.spec.ts',
+      grep: /Anonymous user/,
       use: {
         ...devices['Desktop Chrome'],
       },

--- a/apps/web/playwright/global-setup.ts
+++ b/apps/web/playwright/global-setup.ts
@@ -11,24 +11,23 @@ function parseEnvOutput(output: string): Record<string, string> {
   return result;
 }
 
-export default async () => {
-  const projectDir = process.cwd();
+export async function configurePlaywrightEnv() {
+  const projectDir = path.resolve(__dirname, '..');
   const envTestPath = path.join(projectDir, '.env.test');
-  const envLocalPath = path.join(projectDir, '.env.local');
+  const envTestLocalPath = path.join(projectDir, '.env.test.local');
+  const envProductionLocalPath = path.join(projectDir, '.env.production.local');
 
   console.log('[global-setup] Project dir:', projectDir);
 
-  // Use .env.local as base if .env.test doesn't exist
-  const sourcePath = fs.existsSync(envTestPath) ? envTestPath : envLocalPath;
-  const targetPath = path.join(projectDir, '.env.test.local');
-
-  if (fs.existsSync(sourcePath)) {
-    fs.copyFileSync(sourcePath, targetPath);
-    console.log('[global-setup] Copied env to .env.test.local');
+  if (!fs.existsSync(envTestPath)) {
+    throw new Error(`[global-setup] .env.test not found at ${envTestPath}`);
   }
 
-  // Try to get supabase keys dynamically
-  const databaseDir = path.join(projectDir, '..', '..', 'apps', 'database');
+  fs.copyFileSync(envTestPath, envTestLocalPath);
+  fs.copyFileSync(envTestPath, envProductionLocalPath);
+  console.log('[global-setup] Copied .env.test to .env.test.local and .env.production.local');
+
+  const databaseDir = path.resolve(projectDir, '..', 'database');
   console.log('[global-setup] Running supabase status in:', databaseDir);
 
   try {
@@ -39,17 +38,52 @@ export default async () => {
     });
     const parsed = parseEnvOutput(statusOutput);
     const publishableKey = parsed.PUBLISHABLE_KEY;
+    const apiUrl = parsed.API_URL;
 
-    if (publishableKey && fs.existsSync(targetPath)) {
-      let envContent = fs.readFileSync(targetPath, 'utf-8');
+    if (!(publishableKey && apiUrl)) {
+      throw new Error('[global-setup] Failed to extract Supabase API URL and publishable key');
+    }
+
+    for (const envPath of [envTestLocalPath, envProductionLocalPath]) {
+      let envContent = fs.readFileSync(envPath, 'utf-8');
+      envContent = envContent.replace(
+        /NEXT_PUBLIC_SUPABASE_URL=.*/,
+        `NEXT_PUBLIC_SUPABASE_URL=${apiUrl}/`
+      );
       envContent = envContent.replace(
         /NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=.*/,
         `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=${publishableKey}`
       );
-      fs.writeFileSync(targetPath, envContent);
-      console.log('[global-setup] Updated .env.test.local with Supabase publishable key');
+      envContent = envContent.replace(
+        /NEXT_PUBLIC_SITE_URL=.*/,
+        `NEXT_PUBLIC_SITE_URL=${process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'http://localhost:3000/'}`
+      );
+      fs.writeFileSync(envPath, envContent);
     }
-  } catch {
-    console.warn('[global-setup] Could not get Supabase status — using existing env values');
+    console.log(
+      '[global-setup] Updated .env.test.local and .env.production.local with Supabase settings'
+    );
+  } catch (error) {
+    const err = error as { stderr?: string; stdout?: string; message?: string };
+    console.error('[global-setup] Failed to run supabase status');
+    if (err.stdout) {
+      console.error('[global-setup] stdout:', err.stdout);
+    }
+    if (err.stderr) {
+      console.error('[global-setup] stderr:', err.stderr);
+    }
+    throw new Error(
+      err.message ??
+        '[global-setup] Supabase is not running. Start it with: cd apps/database && pnpm supabase start'
+    );
   }
-};
+}
+
+export default configurePlaywrightEnv;
+
+if (require.main === module) {
+  void configurePlaywrightEnv().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- align the starter Playwright setup with the ultimate-style integration flow without copying extra coverage the starter does not need
- add a dedicated GitHub Actions integration workflow that starts local Supabase, installs Playwright browsers, builds first, runs the e2e suite, and uploads artifacts
- make the starter auth helpers use the correct Mailpit API and normalize magic-link redirects to the active test origin
- replace the dead root-level about spec with runnable anon/public coverage and tighten logged-in/private-item assertions for reliable strict-mode behavior

## Testing
- `pnpm --filter web build`
- `PORT=3100 pnpm run test:e2e`
- `CI=true PORT=3100 pnpm run test:e2e`

## Notes
- intentionally skipped admin/multi-user/onboarding coverage from `nextbase-ultimate` because the starter app surface does not have that seeded setup
- left unrelated working tree changes, including `.oneignore`, untouched