### PR TITLE
chore: ignore .oneignore (legacy CLI artifact)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 # playwright
 test-results/
 playwright/.auth/
+
+# Legacy ascii/one CLI ignore file
+.oneignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Rules
+
+## Do not commit `.oneignore`
+
+Never create a `.oneignore` file. Never `git add` or `git commit` a `.oneignore` file. It is a legacy artifact from the deprecated `one` CLI and must stay out of the repo.


### PR DESCRIPTION
## Summary
- Adds `.oneignore` to root `.gitignore` so the legacy ascii/one CLI ignore file is never committed.

## Notes
- No existing tracked `.oneignore` to remove; only an untracked copy was present locally.