### PR TITLE
chore: add local setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,17 @@
 ## Do not commit `.oneignore`
 
 Never create a `.oneignore` file. Never `git add` or `git commit` a `.oneignore` file. It is a legacy artifact from the deprecated `one` CLI and must stay out of the repo.
+
+# Setup
+
+Follow these steps to get the repo running locally end-to-end. This is a pnpm + Turborepo monorepo with a Next.js app (`apps/web`) and a Supabase local stack (`apps/database`).
+
+1. From the repo root, install dependencies: `pnpm i`.
+2. Check whether `.env.local` already exists at the repo root before creating it.
+3. If `.env.local` does not exist, copy `.env.local.example` to `.env.local`. Never overwrite an existing `.env.local`.
+4. Do the same for `.env.development.local` — if it does not exist, copy `.env.development.local.example` to `.env.development.local`. Never overwrite an existing file.
+5. Env example files in this repo live at the repo root (not alongside `apps/web` or `apps/database`), so create the matching files at the repo root only.
+6. Start the local Supabase stack: from the repo root run `pnpm database#start` (which proxies to `supabase start` inside `apps/database`). Alternatively, `cd apps/database && pnpm start`. If neither is available in your environment, run `pnpm supabase start` from `apps/database`.
+7. Wait for Supabase to finish starting (the CLI prints `API URL`, `DB URL`, and keys) before moving on.
+8. Return to the repo root and run `pnpm supabase:sync-env` to sync the local Supabase keys into your env files.
+9. Start the dev server with `pnpm dev` (runs all apps in parallel) or `pnpm web#dev` for just the web app.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Never create a `.oneignore` file. Never `git add` or `git commit` a `.oneignore`
 
 # Setup
 
+For automated setup, run `./setup.sh` from the repo root. The steps below describe what the script does.
+
 Follow these steps to get the repo running locally end-to-end. This is a pnpm + Turborepo monorepo with a Next.js app (`apps/web`) and a Supabase local stack (`apps/database`).
 
 1. From the repo root, install dependencies: `pnpm i`.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stop any stale Supabase containers from a previous run to avoid port-bind failures.
+( cd apps/database && pnpm supabase stop --no-backup 2>/dev/null || true ) || true
+
+# Copy .env*.example files to their .env counterparts if missing.
+# Covers repo root, apps/*, and packages/*.
+while IFS= read -r ex; do
+  target="${ex%.example}"
+  if [ ! -f "$target" ]; then
+    cp "$ex" "$target"
+    echo "Created $target"
+  fi
+done < <(find . \( -name ".env.local.example" -o -name ".env.development.local.example" \) -not -path "*/node_modules/*" -not -path "*/.git/*")
+
+# Install dependencies.
+pnpm i
+
+# Bring up the local Supabase stack.
+pnpm database#start
+
+# Sync local Supabase keys into env files (non-fatal if it fails).
+pnpm supabase:sync-env || true
+
+# Generate local DB types (non-fatal).
+pnpm gen-types-local || true
+
+echo "Setup complete"


### PR DESCRIPTION
## Summary

- Adds a `# Setup` section to `AGENTS.md` so future Task Agents can get the repo running locally end-to-end without guesswork.
- Documents the actual env-file layout (examples live at the repo root, not next to `apps/*`), the Supabase bring-up via `pnpm database#start` (or `cd apps/database && pnpm start`), and the `pnpm supabase:sync-env` step.

A matching `ascii routines` setup script (trigger `on_task_start`) was registered to automate the same steps for fresh Task Agents.

## Test plan

- [ ] Fresh Task Agent on this repo runs the setup routine and ends up with `.env.local`, `.env.development.local`, deps installed, Supabase running, and synced env.