### PR TITLE
refactor(web): extract page sections into co-located components

### DIFF
--- a/apps/web/src/app/(app-pages)/dashboard/dashboard-heading.tsx
+++ b/apps/web/src/app/(app-pages)/dashboard/dashboard-heading.tsx
@@ -1,0 +1,18 @@
+import { Button } from '@/components/ui/button';
+import { T } from '@/components/ui/Typography';
+import { PlusCircle } from 'lucide-react';
+import Link from 'next/link';
+
+export async function DashboardHeading() {
+  'use cache';
+  return (
+    <>
+      <T.H1>Dashboard</T.H1>
+      <Link href="/dashboard/new">
+        <Button className="flex items-center gap-2">
+          <PlusCircle className="h-4 w-4" /> New Private Item
+        </Button>
+      </Link>
+    </>
+  );
+}

--- a/apps/web/src/app/(app-pages)/dashboard/dashboard-list-skeleton.tsx
+++ b/apps/web/src/app/(app-pages)/dashboard/dashboard-list-skeleton.tsx
@@ -1,0 +1,30 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function DashboardListSkeleton() {
+  return (
+    <div className="space-y-8">
+      <div className="flex justify-between items-center">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-40" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <Skeleton className="h-10 w-32" />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-full mb-2" />
+          <Skeleton className="h-4 w-3/4" />
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {Array(3)
+            .fill(0)
+            .map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full" />
+            ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app-pages)/dashboard/dashboard-private-items-section.tsx
+++ b/apps/web/src/app/(app-pages)/dashboard/dashboard-private-items-section.tsx
@@ -1,0 +1,13 @@
+import { PrivateItemsList } from '@/app/(app-pages)/PrivateItemsList';
+import type { Table as TableType } from '@/types';
+
+interface DashboardPrivateItemsSectionProps {
+  privateItemsPromise: Promise<TableType<'private_items'>[]>;
+}
+
+export async function DashboardPrivateItemsSection({
+  privateItemsPromise,
+}: DashboardPrivateItemsSectionProps) {
+  const privateItems = await privateItemsPromise;
+  return <PrivateItemsList privateItems={privateItems} showActions={false} />;
+}

--- a/apps/web/src/app/(app-pages)/dashboard/page.tsx
+++ b/apps/web/src/app/(app-pages)/dashboard/page.tsx
@@ -1,67 +1,16 @@
-import { PrivateItemsList } from '@/app/(app-pages)/PrivateItemsList';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { Skeleton } from '@/components/ui/skeleton';
-import { T } from '@/components/ui/Typography';
 import { getUserPrivateItems } from '@/data/anon/privateItems';
-import { PlusCircle } from 'lucide-react';
-import Link from 'next/link';
 import { Suspense } from 'react';
-
-
-async function UserPrivateItemsListContainer() {
-  const privateItems = await getUserPrivateItems();
-  return <PrivateItemsList privateItems={privateItems} showActions={false} />;
-}
-
-function ListSkeleton() {
-  return (
-    <div className="space-y-8">
-      <div className="flex justify-between items-center">
-        <div className="space-y-2">
-          <Skeleton className="h-8 w-40" />
-          <Skeleton className="h-4 w-64" />
-        </div>
-        <Skeleton className="h-10 w-32" />
-      </div>
-
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-6 w-full mb-2" />
-          <Skeleton className="h-4 w-3/4" />
-        </CardHeader>
-        <CardContent className="space-y-2">
-          {Array(3)
-            .fill(0)
-            .map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full" />
-            ))}
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-async function Heading() {
-  'use cache';
-  return (
-    <>
-      <T.H1>Dashboard</T.H1>
-      <Link href="/dashboard/new">
-        <Button className="flex items-center gap-2">
-          <PlusCircle className="h-4 w-4" /> New Private Item
-        </Button>
-      </Link>
-    </>
-  );
-};
+import { DashboardHeading } from './dashboard-heading';
+import { DashboardListSkeleton } from './dashboard-list-skeleton';
+import { DashboardPrivateItemsSection } from './dashboard-private-items-section';
 
 export default function DashboardPage() {
+  const privateItemsPromise = getUserPrivateItems();
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 md:p-6">
-      <Heading />
-      <Suspense fallback={<ListSkeleton />}>
-        <UserPrivateItemsListContainer />
+      <DashboardHeading />
+      <Suspense fallback={<DashboardListSkeleton />}>
+        <DashboardPrivateItemsSection privateItemsPromise={privateItemsPromise} />
       </Suspense>
     </div>
   );

--- a/apps/web/src/app/(app-pages)/private-item/[privateItemId]/page.tsx
+++ b/apps/web/src/app/(app-pages)/private-item/[privateItemId]/page.tsx
@@ -1,111 +1,21 @@
-import { T } from '@/components/ui/Typography';
-import { Button } from '@/components/ui/button';
-import { ButtonGroup } from '@/components/ui/button-group';
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-} from '@/components/ui/card';
-import { Separator } from '@/components/ui/separator';
-import { Skeleton } from '@/components/ui/skeleton';
 import { getPrivateItem } from '@/data/anon/privateItems';
-import { Calendar, Info } from 'lucide-react';
-import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
-import { ConfirmDeleteItemDialog } from './ConfirmDeleteItemDialog';
-
-async function PrivateItem({ params }: { params: Promise<{ privateItemId: string }> }) {
-  const { privateItemId } = await params;
-  const item = await getPrivateItem(privateItemId);
-
-  return (
-    <div className="space-y-4">
-
-
-      <Card className="shadow-md border-t-4 border-t-primary">
-        <CardHeader className="pb-2">
-          <T.H2 className="mb-1">{item.name}</T.H2>
-          <div className="flex items-center gap-1 text-muted-foreground text-sm">
-            <Info className="h-3 w-3" />
-            <span>Private Item</span>
-          </div>
-        </CardHeader>
-        <Separator />
-        <CardContent className="pt-5">
-          <div className="space-y-4">
-            <div>
-              <T.Small className="text-muted-foreground">Description</T.Small>
-              <T.P className="mt-1">{item.description}</T.P>
-            </div>
-
-            {item.created_at && (
-              <div className="flex items-center gap-1 text-muted-foreground text-sm">
-                <Calendar className="h-3 w-3" />
-                <span>
-                  Created on {new Date(item.created_at).toLocaleDateString()}
-                </span>
-              </div>
-            )}
-          </div>
-        </CardContent>
-        <CardFooter className="border-t pt-4">
-          <ButtonGroup className="w-full justify-between">
-            <Button variant="outline" asChild>
-              <Link href="/dashboard">Back to Dashboard</Link>
-            </Button>
-            <ConfirmDeleteItemDialog itemId={privateItemId} />
-          </ButtonGroup>
-        </CardFooter>
-      </Card>
-    </div>
-  );
-}
-
-// Loading skeleton component
-function PrivateItemSkeleton() {
-  return (
-    <Card className="shadow-md">
-      <CardHeader className="pb-2">
-        <div className="flex justify-between items-start">
-          <Skeleton className="h-6 w-32 mb-4" />
-        </div>
-        <Skeleton className="h-8 w-72 mb-1" />
-        <Skeleton className="h-4 w-24" />
-      </CardHeader>
-      <Separator />
-      <CardContent className="pt-5">
-        <div className="space-y-4">
-          <div>
-            <Skeleton className="h-4 w-24 mb-2" />
-            <Skeleton className="h-16 w-full" />
-          </div>
-          <Skeleton className="h-4 w-48" />
-        </div>
-      </CardContent>
-      <CardFooter className="flex justify-between border-t pt-4">
-        <Skeleton className="h-10 w-40" />
-        <Skeleton className="h-10 w-32" />
-      </CardFooter>
-    </Card>
-  );
-}
-
-
+import { PrivateItemCard } from './private-item-card';
+import { PrivateItemSkeleton } from './private-item-skeleton';
 
 export default async function PrivateItemPage({ params }: {
   params: Promise<{
     privateItemId: string;
   }>;
 }) {
-
-
   try {
+    const { privateItemId } = await params;
+    const itemPromise = getPrivateItem(privateItemId);
     return (
       <div className="flex flex-1 flex-col gap-4 p-4 md:p-6 max-w-2xl mx-auto w-full">
         <Suspense fallback={<PrivateItemSkeleton />}>
-          <PrivateItem params={params} />
+          <PrivateItemCard privateItemId={privateItemId} itemPromise={itemPromise} />
         </Suspense>
       </div>
     );

--- a/apps/web/src/app/(app-pages)/private-item/[privateItemId]/private-item-card.tsx
+++ b/apps/web/src/app/(app-pages)/private-item/[privateItemId]/private-item-card.tsx
@@ -1,0 +1,68 @@
+import { Button } from '@/components/ui/button';
+import { ButtonGroup } from '@/components/ui/button-group';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { T } from '@/components/ui/Typography';
+import type { Table as TableType } from '@/types';
+import { Calendar, Info } from 'lucide-react';
+import Link from 'next/link';
+import { ConfirmDeleteItemDialog } from './ConfirmDeleteItemDialog';
+
+interface PrivateItemCardProps {
+  privateItemId: string;
+  itemPromise: Promise<TableType<'private_items'>>;
+}
+
+export async function PrivateItemCard({
+  privateItemId,
+  itemPromise,
+}: PrivateItemCardProps) {
+  const item = await itemPromise;
+
+  return (
+    <div className="space-y-4">
+
+
+      <Card className="shadow-md border-t-4 border-t-primary">
+        <CardHeader className="pb-2">
+          <T.H2 className="mb-1">{item.name}</T.H2>
+          <div className="flex items-center gap-1 text-muted-foreground text-sm">
+            <Info className="h-3 w-3" />
+            <span>Private Item</span>
+          </div>
+        </CardHeader>
+        <Separator />
+        <CardContent className="pt-5">
+          <div className="space-y-4">
+            <div>
+              <T.Small className="text-muted-foreground">Description</T.Small>
+              <T.P className="mt-1">{item.description}</T.P>
+            </div>
+
+            {item.created_at && (
+              <div className="flex items-center gap-1 text-muted-foreground text-sm">
+                <Calendar className="h-3 w-3" />
+                <span>
+                  Created on {new Date(item.created_at).toLocaleDateString()}
+                </span>
+              </div>
+            )}
+          </div>
+        </CardContent>
+        <CardFooter className="border-t pt-4">
+          <ButtonGroup className="w-full justify-between">
+            <Button variant="outline" asChild>
+              <Link href="/dashboard">Back to Dashboard</Link>
+            </Button>
+            <ConfirmDeleteItemDialog itemId={privateItemId} />
+          </ButtonGroup>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app-pages)/private-item/[privateItemId]/private-item-skeleton.tsx
+++ b/apps/web/src/app/(app-pages)/private-item/[privateItemId]/private-item-skeleton.tsx
@@ -1,0 +1,36 @@
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function PrivateItemSkeleton() {
+  return (
+    <Card className="shadow-md">
+      <CardHeader className="pb-2">
+        <div className="flex justify-between items-start">
+          <Skeleton className="h-6 w-32 mb-4" />
+        </div>
+        <Skeleton className="h-8 w-72 mb-1" />
+        <Skeleton className="h-4 w-24" />
+      </CardHeader>
+      <Separator />
+      <CardContent className="pt-5">
+        <div className="space-y-4">
+          <div>
+            <Skeleton className="h-4 w-24 mb-2" />
+            <Skeleton className="h-16 w-full" />
+          </div>
+          <Skeleton className="h-4 w-48" />
+        </div>
+      </CardContent>
+      <CardFooter className="flex justify-between border-t pt-4">
+        <Skeleton className="h-10 w-40" />
+        <Skeleton className="h-10 w-32" />
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(app-pages)/private-items/page.tsx
+++ b/apps/web/src/app/(app-pages)/private-items/page.tsx
@@ -1,72 +1,17 @@
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { Skeleton } from '@/components/ui/skeleton';
-import { T } from '@/components/ui/Typography';
 import { getUserPrivateItems } from '@/data/anon/privateItems';
-import { Lock, PlusCircle } from 'lucide-react';
-import Link from 'next/link';
 import { Suspense } from 'react';
-import { PrivateItemsList } from '../PrivateItemsList';
-
-
-function PrivateItemsListSkeleton() {
-  return (
-    <div className="space-y-8">
-      <div className="flex justify-between items-center">
-        <div className="space-y-2">
-          <Skeleton className="h-8 w-40" />
-          <Skeleton className="h-4 w-64" />
-        </div>
-        <Skeleton className="h-10 w-32" />
-      </div>
-
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-6 w-full mb-2" />
-        </CardHeader>
-        <CardContent className="space-y-2">
-          {Array(3)
-            .fill(0)
-            .map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full" />
-            ))}
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-async function PrivateItemsListWrapper() {
-  // this loads data from supabase and internally
-  // uses cookies() which is a Dynamic API
-  // Hence must be wrapped in a Suspense
-  const privateItems = await getUserPrivateItems();
-  return <PrivateItemsList privateItems={privateItems} />;
-}
+import { PrivateItemsHeader } from './private-items-header';
+import { PrivateItemsListSection } from './private-items-list-section';
+import { PrivateItemsListSkeleton } from './private-items-list-skeleton';
 
 export default function PrivateItemsPage() {
+  const privateItemsPromise = getUserPrivateItems();
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 md:p-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <T.H1>Private Items</T.H1>
-          <Badge variant="outline" className="h-6 flex items-center gap-1">
-            <Lock className="h-3 w-3" /> Secure
-          </Badge>
-        </div>
-        <Link href="/dashboard/new">
-          <Button className="flex items-center gap-2">
-            <PlusCircle className="h-4 w-4" /> New Private Item
-          </Button>
-        </Link>
-      </div>
-      <T.Subtle className="mb-4">
-        Browse your private items that only you can access
-      </T.Subtle>
+      <PrivateItemsHeader />
 
       <Suspense fallback={<PrivateItemsListSkeleton />}>
-        <PrivateItemsListWrapper />
+        <PrivateItemsListSection privateItemsPromise={privateItemsPromise} />
       </Suspense>
     </div>
   );

--- a/apps/web/src/app/(app-pages)/private-items/private-items-header.tsx
+++ b/apps/web/src/app/(app-pages)/private-items/private-items-header.tsx
@@ -1,0 +1,28 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { T } from '@/components/ui/Typography';
+import { Lock, PlusCircle } from 'lucide-react';
+import Link from 'next/link';
+
+export function PrivateItemsHeader() {
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <T.H1>Private Items</T.H1>
+          <Badge variant="outline" className="h-6 flex items-center gap-1">
+            <Lock className="h-3 w-3" /> Secure
+          </Badge>
+        </div>
+        <Link href="/dashboard/new">
+          <Button className="flex items-center gap-2">
+            <PlusCircle className="h-4 w-4" /> New Private Item
+          </Button>
+        </Link>
+      </div>
+      <T.Subtle className="mb-4">
+        Browse your private items that only you can access
+      </T.Subtle>
+    </>
+  );
+}

--- a/apps/web/src/app/(app-pages)/private-items/private-items-list-section.tsx
+++ b/apps/web/src/app/(app-pages)/private-items/private-items-list-section.tsx
@@ -1,0 +1,16 @@
+import type { Table as TableType } from '@/types';
+import { PrivateItemsList } from '../PrivateItemsList';
+
+interface PrivateItemsListSectionProps {
+  privateItemsPromise: Promise<TableType<'private_items'>[]>;
+}
+
+export async function PrivateItemsListSection({
+  privateItemsPromise,
+}: PrivateItemsListSectionProps) {
+  // this loads data from supabase and internally
+  // uses cookies() which is a Dynamic API
+  // Hence must be wrapped in a Suspense
+  const privateItems = await privateItemsPromise;
+  return <PrivateItemsList privateItems={privateItems} />;
+}

--- a/apps/web/src/app/(app-pages)/private-items/private-items-list-skeleton.tsx
+++ b/apps/web/src/app/(app-pages)/private-items/private-items-list-skeleton.tsx
@@ -1,0 +1,29 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function PrivateItemsListSkeleton() {
+  return (
+    <div className="space-y-8">
+      <div className="flex justify-between items-center">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-40" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <Skeleton className="h-10 w-32" />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-full mb-2" />
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {Array(3)
+            .fill(0)
+            .map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full" />
+            ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/(external-pages)/about/about-cta.tsx
+++ b/apps/web/src/app/(external-pages)/about/about-cta.tsx
@@ -1,0 +1,44 @@
+import { Button } from '@/components/ui/button';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
+import { Github, Rocket } from 'lucide-react';
+import Link from 'next/link';
+
+export function AboutCTA() {
+  return (
+    <Empty className="border-2 border-dashed">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <Rocket />
+        </EmptyMedia>
+        <EmptyTitle>Ready to Build Something Amazing?</EmptyTitle>
+        <EmptyDescription>
+          Clone the repository and start building your next project with the
+          best tools in the ecosystem.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <div className="flex flex-wrap gap-3 justify-center">
+          <Button size="lg" asChild>
+            <Link href="/sign-up">Start Building</Link>
+          </Button>
+          <Button size="lg" variant="outline" asChild>
+            <Link
+              href="https://github.com/imbhargav5/nextbase-nextjs-supabase-starter"
+              target="_blank"
+            >
+              <Github className="mr-2 h-5 w-5" />
+              Star on GitHub
+            </Link>
+          </Button>
+        </div>
+      </EmptyContent>
+    </Empty>
+  );
+}

--- a/apps/web/src/app/(external-pages)/about/about-features-grid.tsx
+++ b/apps/web/src/app/(external-pages)/about/about-features-grid.tsx
@@ -1,0 +1,133 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { T } from '@/components/ui/Typography';
+import {
+  Database,
+  Lock,
+  Palette,
+  Rocket,
+  Shield,
+  Zap,
+} from 'lucide-react';
+
+export function AboutFeaturesGrid() {
+  return (
+    <div className="space-y-6">
+      <div className="text-center space-y-2">
+        <T.H2 className="text-3xl">Built for Developers</T.H2>
+        <T.P className="text-muted-foreground">
+          Everything you need to build production-ready applications
+        </T.P>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10">
+                <Rocket className="h-6 w-6 text-primary" />
+              </div>
+              <CardTitle>Next.js 14</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <CardDescription>
+              Built on the latest Next.js with App Router, Server Components,
+              and Server Actions for optimal performance.
+            </CardDescription>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-chart-2/10">
+                <Database className="h-6 w-6 text-chart-2" />
+              </div>
+              <CardTitle>Supabase</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <CardDescription>
+              PostgreSQL database, authentication, real-time subscriptions,
+              and storage - all in one platform.
+            </CardDescription>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10">
+                <Shield className="h-6 w-6 text-primary" />
+              </div>
+              <CardTitle>Type-Safe</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <CardDescription>
+              Full TypeScript support with type-safe database queries and API
+              routes for confidence in your code.
+            </CardDescription>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-chart-4/10">
+                <Palette className="h-6 w-6 text-chart-4" />
+              </div>
+              <CardTitle>shadcn/ui</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <CardDescription>
+              Beautiful, accessible components built with Radix UI and
+              Tailwind CSS. Customizable and production-ready.
+            </CardDescription>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-chart-1/10">
+                <Lock className="h-6 w-6 text-chart-1" />
+              </div>
+              <CardTitle>Authentication</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <CardDescription>
+              Complete auth flows including magic links, OAuth providers,
+              password reset, and protected routes.
+            </CardDescription>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-chart-5/10">
+                <Zap className="h-6 w-6 text-chart-5" />
+              </div>
+              <CardTitle>Developer UX</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <CardDescription>
+              Hot reload, TypeScript, ESLint, Prettier, and more. Optimized
+              for the best developer experience.
+            </CardDescription>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(external-pages)/about/about-hero.tsx
+++ b/apps/web/src/app/(external-pages)/about/about-hero.tsx
@@ -1,0 +1,39 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { T } from '@/components/ui/Typography';
+import { Github } from 'lucide-react';
+import Link from 'next/link';
+
+export function AboutHero() {
+  return (
+    <div className="text-center space-y-4">
+      <Badge variant="outline" className="mb-4">
+        About Nextbase
+      </Badge>
+      <T.H1 className="text-4xl sm:text-5xl md:text-6xl">
+        Modern Full-Stack{' '}
+        <span className="bg-gradient-to-r from-primary to-primary bg-clip-text text-transparent">
+          Starter Kit
+        </span>
+      </T.H1>
+      <T.P className="mx-auto max-w-[700px] text-lg text-muted-foreground">
+        Built with Next.js, TypeScript, Supabase, and shadcn/ui. Everything
+        you need to ship your next SaaS product fast.
+      </T.P>
+      <div className="flex flex-wrap justify-center gap-4 pt-4">
+        <Button size="lg" asChild>
+          <Link href="/login">Get Started</Link>
+        </Button>
+        <Button size="lg" variant="outline" asChild>
+          <Link
+            href="https://github.com/imbhargav5/nextbase-nextjs-supabase-starter"
+            target="_blank"
+          >
+            <Github className="mr-2 h-5 w-5" />
+            View on GitHub
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(external-pages)/about/about-tech-stack.tsx
+++ b/apps/web/src/app/(external-pages)/about/about-tech-stack.tsx
@@ -1,0 +1,34 @@
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+interface AboutTechStackProps {
+  technologies: string[];
+}
+
+export function AboutTechStack({ technologies }: AboutTechStackProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Technology Stack</CardTitle>
+        <CardDescription>
+          Built with modern, production-ready technologies
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {technologies.map((tech) => (
+            <div key={tech} className="flex items-center gap-2">
+              <Badge>{tech}</Badge>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(external-pages)/about/page.tsx
+++ b/apps/web/src/app/(external-pages)/about/page.tsx
@@ -1,247 +1,26 @@
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import {
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from '@/components/ui/empty';
-import { T } from '@/components/ui/Typography';
-import {
-  Database,
-  Github,
-  Lock,
-  Palette,
-  Rocket,
-  Shield,
-  Zap,
-} from 'lucide-react';
-import Link from 'next/link';
+import { AboutCTA } from './about-cta';
+import { AboutFeaturesGrid } from './about-features-grid';
+import { AboutHero } from './about-hero';
+import { AboutTechStack } from './about-tech-stack';
+
+const technologies = [
+  'Next.js 14',
+  'TypeScript',
+  'Supabase',
+  'Tailwind CSS',
+  'shadcn/ui',
+  'React Hook Form',
+  'Zod',
+  'Framer Motion',
+];
 
 export default function About() {
   return (
     <div className="container mx-auto py-12 space-y-12 max-w-6xl">
-      {/* Hero Section */}
-      <div className="text-center space-y-4">
-        <Badge variant="outline" className="mb-4">
-          About Nextbase
-        </Badge>
-        <T.H1 className="text-4xl sm:text-5xl md:text-6xl">
-          Modern Full-Stack{' '}
-          <span className="bg-gradient-to-r from-primary to-primary bg-clip-text text-transparent">
-            Starter Kit
-          </span>
-        </T.H1>
-        <T.P className="mx-auto max-w-[700px] text-lg text-muted-foreground">
-          Built with Next.js, TypeScript, Supabase, and shadcn/ui. Everything
-          you need to ship your next SaaS product fast.
-        </T.P>
-        <div className="flex flex-wrap justify-center gap-4 pt-4">
-          <Button size="lg" asChild>
-            <Link href="/login">Get Started</Link>
-          </Button>
-          <Button size="lg" variant="outline" asChild>
-            <Link
-              href="https://github.com/imbhargav5/nextbase-nextjs-supabase-starter"
-              target="_blank"
-            >
-              <Github className="mr-2 h-5 w-5" />
-              View on GitHub
-            </Link>
-          </Button>
-        </div>
-      </div>
-
-      {/* Features Grid */}
-      <div className="space-y-6">
-        <div className="text-center space-y-2">
-          <T.H2 className="text-3xl">Built for Developers</T.H2>
-          <T.P className="text-muted-foreground">
-            Everything you need to build production-ready applications
-          </T.P>
-        </div>
-
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-3">
-                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10">
-                  <Rocket className="h-6 w-6 text-primary" />
-                </div>
-                <CardTitle>Next.js 14</CardTitle>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <CardDescription>
-                Built on the latest Next.js with App Router, Server Components,
-                and Server Actions for optimal performance.
-              </CardDescription>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-3">
-                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-chart-2/10">
-                  <Database className="h-6 w-6 text-chart-2" />
-                </div>
-                <CardTitle>Supabase</CardTitle>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <CardDescription>
-                PostgreSQL database, authentication, real-time subscriptions,
-                and storage - all in one platform.
-              </CardDescription>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-3">
-                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10">
-                  <Shield className="h-6 w-6 text-primary" />
-                </div>
-                <CardTitle>Type-Safe</CardTitle>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <CardDescription>
-                Full TypeScript support with type-safe database queries and API
-                routes for confidence in your code.
-              </CardDescription>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-3">
-                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-chart-4/10">
-                  <Palette className="h-6 w-6 text-chart-4" />
-                </div>
-                <CardTitle>shadcn/ui</CardTitle>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <CardDescription>
-                Beautiful, accessible components built with Radix UI and
-                Tailwind CSS. Customizable and production-ready.
-              </CardDescription>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-3">
-                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-chart-1/10">
-                  <Lock className="h-6 w-6 text-chart-1" />
-                </div>
-                <CardTitle>Authentication</CardTitle>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <CardDescription>
-                Complete auth flows including magic links, OAuth providers,
-                password reset, and protected routes.
-              </CardDescription>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <div className="flex items-center gap-3">
-                <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-chart-5/10">
-                  <Zap className="h-6 w-6 text-chart-5" />
-                </div>
-                <CardTitle>Developer UX</CardTitle>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <CardDescription>
-                Hot reload, TypeScript, ESLint, Prettier, and more. Optimized
-                for the best developer experience.
-              </CardDescription>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-
-      {/* CTA Section */}
-      <Empty className="border-2 border-dashed">
-        <EmptyHeader>
-          <EmptyMedia variant="icon">
-            <Rocket />
-          </EmptyMedia>
-          <EmptyTitle>Ready to Build Something Amazing?</EmptyTitle>
-          <EmptyDescription>
-            Clone the repository and start building your next project with the
-            best tools in the ecosystem.
-          </EmptyDescription>
-        </EmptyHeader>
-        <EmptyContent>
-          <div className="flex flex-wrap gap-3 justify-center">
-            <Button size="lg" asChild>
-              <Link href="/sign-up">Start Building</Link>
-            </Button>
-            <Button size="lg" variant="outline" asChild>
-              <Link
-                href="https://github.com/imbhargav5/nextbase-nextjs-supabase-starter"
-                target="_blank"
-              >
-                <Github className="mr-2 h-5 w-5" />
-                Star on GitHub
-              </Link>
-            </Button>
-          </div>
-        </EmptyContent>
-      </Empty>
-
-      {/* Tech Stack Section */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Technology Stack</CardTitle>
-          <CardDescription>
-            Built with modern, production-ready technologies
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            <div className="flex items-center gap-2">
-              <Badge>Next.js 14</Badge>
-            </div>
-            <div className="flex items-center gap-2">
-              <Badge>TypeScript</Badge>
-            </div>
-            <div className="flex items-center gap-2">
-              <Badge>Supabase</Badge>
-            </div>
-            <div className="flex items-center gap-2">
-              <Badge>Tailwind CSS</Badge>
-            </div>
-            <div className="flex items-center gap-2">
-              <Badge>shadcn/ui</Badge>
-            </div>
-            <div className="flex items-center gap-2">
-              <Badge>React Hook Form</Badge>
-            </div>
-            <div className="flex items-center gap-2">
-              <Badge>Zod</Badge>
-            </div>
-            <div className="flex items-center gap-2">
-              <Badge>Framer Motion</Badge>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      <AboutHero />
+      <AboutFeaturesGrid />
+      <AboutCTA />
+      <AboutTechStack technologies={technologies} />
     </div>
   );
 }

--- a/apps/web/src/app/(external-pages)/home-cta.tsx
+++ b/apps/web/src/app/(external-pages)/home-cta.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@/components/ui/button';
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+
+export function HomeCTA() {
+  return (
+    <section className="py-20 px-4 text-center">
+      <div className="max-w-xl mx-auto flex flex-col gap-4 items-center">
+        <h2 className="text-3xl font-bold tracking-tight">Ready to build?</h2>
+        <p className="text-muted-foreground">
+          Start with a solid foundation and ship faster.
+        </p>
+        <Button asChild size="lg">
+          <Link href="/sign-up">
+            Start for free <ArrowRight className="ml-2 h-4 w-4" />
+          </Link>
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/(external-pages)/home-features.tsx
+++ b/apps/web/src/app/(external-pages)/home-features.tsx
@@ -1,0 +1,42 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { LucideIcon } from 'lucide-react';
+
+export interface HomeFeature {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+}
+
+interface HomeFeaturesProps {
+  features: HomeFeature[];
+}
+
+export function HomeFeatures({ features }: HomeFeaturesProps) {
+  return (
+    <section className="py-20 px-4">
+      <div className="max-w-5xl mx-auto">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl font-bold tracking-tight">Everything you need</h2>
+          <p className="text-muted-foreground mt-2">
+            Production-ready features included out of the box
+          </p>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {features.map((feature) => (
+            <Card key={feature.title} className="border bg-card">
+              <CardHeader className="pb-2">
+                <div className="flex items-center gap-2">
+                  <feature.icon className="h-5 w-5 text-primary" />
+                  <CardTitle className="text-base">{feature.title}</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <CardDescription>{feature.description}</CardDescription>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/(external-pages)/home-hero.tsx
+++ b/apps/web/src/app/(external-pages)/home-hero.tsx
@@ -1,0 +1,34 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ArrowRight, Github } from 'lucide-react';
+import Link from 'next/link';
+
+export function HomeHero() {
+  return (
+    <section className="flex flex-col items-center justify-center gap-6 py-24 px-4 text-center">
+      <Badge variant="secondary" className="px-3 py-1">
+        Open Source Starter Kit
+      </Badge>
+      <h1 className="text-4xl font-bold tracking-tight sm:text-6xl max-w-3xl">
+        Build your{' '}
+        <span className="text-primary">SaaS product</span>{' '}
+        faster
+      </h1>
+      <p className="text-muted-foreground text-lg max-w-xl">
+        A production-ready Next.js + Supabase starter with authentication, database, UI components, and everything you need.
+      </p>
+      <div className="flex flex-wrap gap-3 justify-center">
+        <Button asChild size="lg">
+          <Link href="/sign-up">
+            Get Started <ArrowRight className="ml-2 h-4 w-4" />
+          </Link>
+        </Button>
+        <Button asChild size="lg" variant="outline">
+          <Link href="https://github.com/imbhargav5/nextbase-nextjs-supabase-starter" target="_blank" rel="noopener noreferrer">
+            <Github className="mr-2 h-4 w-4" /> View on GitHub
+          </Link>
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/(external-pages)/page.tsx
+++ b/apps/web/src/app/(external-pages)/page.tsx
@@ -1,11 +1,10 @@
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
-import { ArrowRight, Database, Github, Lock, Palette, Shield, Zap } from 'lucide-react';
-import Link from 'next/link';
+import { ArrowRight, Database, Lock, Palette, Shield, Zap } from 'lucide-react';
+import { HomeCTA } from './home-cta';
+import { HomeFeatures, type HomeFeature } from './home-features';
+import { HomeHero } from './home-hero';
 
-const features = [
+const features: HomeFeature[] = [
   {
     icon: Shield,
     title: 'Type-Safe',
@@ -41,78 +40,11 @@ const features = [
 export default function HomePage() {
   return (
     <div className="flex flex-col">
-      {/* Hero */}
-      <section className="flex flex-col items-center justify-center gap-6 py-24 px-4 text-center">
-        <Badge variant="secondary" className="px-3 py-1">
-          Open Source Starter Kit
-        </Badge>
-        <h1 className="text-4xl font-bold tracking-tight sm:text-6xl max-w-3xl">
-          Build your{' '}
-          <span className="text-primary">SaaS product</span>{' '}
-          faster
-        </h1>
-        <p className="text-muted-foreground text-lg max-w-xl">
-          A production-ready Next.js + Supabase starter with authentication, database, UI components, and everything you need.
-        </p>
-        <div className="flex flex-wrap gap-3 justify-center">
-          <Button asChild size="lg">
-            <Link href="/sign-up">
-              Get Started <ArrowRight className="ml-2 h-4 w-4" />
-            </Link>
-          </Button>
-          <Button asChild size="lg" variant="outline">
-            <Link href="https://github.com/imbhargav5/nextbase-nextjs-supabase-starter" target="_blank" rel="noopener noreferrer">
-              <Github className="mr-2 h-4 w-4" /> View on GitHub
-            </Link>
-          </Button>
-        </div>
-      </section>
-
+      <HomeHero />
       <Separator />
-
-      {/* Features */}
-      <section className="py-20 px-4">
-        <div className="max-w-5xl mx-auto">
-          <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold tracking-tight">Everything you need</h2>
-            <p className="text-muted-foreground mt-2">
-              Production-ready features included out of the box
-            </p>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {features.map((feature) => (
-              <Card key={feature.title} className="border bg-card">
-                <CardHeader className="pb-2">
-                  <div className="flex items-center gap-2">
-                    <feature.icon className="h-5 w-5 text-primary" />
-                    <CardTitle className="text-base">{feature.title}</CardTitle>
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription>{feature.description}</CardDescription>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
-      </section>
-
+      <HomeFeatures features={features} />
       <Separator />
-
-      {/* CTA */}
-      <section className="py-20 px-4 text-center">
-        <div className="max-w-xl mx-auto flex flex-col gap-4 items-center">
-          <h2 className="text-3xl font-bold tracking-tight">Ready to build?</h2>
-          <p className="text-muted-foreground">
-            Start with a solid foundation and ship faster.
-          </p>
-          <Button asChild size="lg">
-            <Link href="/sign-up">
-              Start for free <ArrowRight className="ml-2 h-4 w-4" />
-            </Link>
-          </Button>
-        </div>
-      </section>
+      <HomeCTA />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Extract reasonably sized page sections from every route in `apps/web/src/app` into separate components co-located beside their `page.tsx`.
- `page.tsx` now owns data loading and injects props (including unawaited promises passed through Suspense) into the extracted section components.
- Structural change only: markup, styling, routing, server/client behavior, Suspense boundaries, `'use cache'`, auth guards, and existing user flows are preserved.

### Extracted sections per page
- `(external-pages)/page.tsx` → `home-hero.tsx`, `home-features.tsx`, `home-cta.tsx`
- `(external-pages)/about/page.tsx` → `about-hero.tsx`, `about-features-grid.tsx`, `about-cta.tsx`, `about-tech-stack.tsx`
- `(app-pages)/dashboard/page.tsx` → `dashboard-heading.tsx`, `dashboard-list-skeleton.tsx`, `dashboard-private-items-section.tsx`
- `(app-pages)/private-items/page.tsx` → `private-items-header.tsx`, `private-items-list-section.tsx`, `private-items-list-skeleton.tsx`
- `(app-pages)/private-item/[privateItemId]/page.tsx` → `private-item-card.tsx`, `private-item-skeleton.tsx`

Tiny pages (`dashboard/new`, `forgot-password`, `auth/auth-code-error`, `login`, `sign-up`, `update-password`) already delegated to existing co-located components and were left unchanged.

### pnpm minimum package age
The `minimumReleaseAge: 4320` (3 days, in minutes) rule was already present in `pnpm-workspace.yaml`, so no change was required for this task item.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build` (all routes generate)
- [ ] Manual smoke through `/`, `/about`, `/dashboard`, `/private-items`, `/private-item/[id]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)