### PR TITLE
chore: remove redundant env type lint suppression

### DIFF
--- a/apps/web/src/environment.d.ts
+++ b/apps/web/src/environment.d.ts
@@ -9,6 +9,4 @@ declare global {
   }
 }
 
-// eslint-disable-next-line prettier/prettier
-export { };
-
+export {};


### PR DESCRIPTION
## Summary
- remove the unnecessary prettier lint suppression in the web environment type declarations
- keep the file as a module using the standard empty export form

## Verification
- pnpm --filter web lint
- pnpm --filter web typecheck
- pnpm --filter web test