### PR TITLE
docs(web): fix URL helper trailing slash comment

### DIFF
--- a/apps/web/src/utils/helpers.ts
+++ b/apps/web/src/utils/helpers.ts
@@ -8,7 +8,7 @@ export const getURL = () => {
     `http://localhost:${DEV_PORT}/`;
   // Make sure to include `https://` when not localhost.
   url = url.startsWith('http') ? url : `https://${url}`;
-  // Make sure to including trailing `/`.
+  // Make sure to include a trailing `/`.
   url = url.charAt(url.length - 1) === '/' ? url : `${url}/`;
   return url;
 };


### PR DESCRIPTION
## Summary
- fix a grammar typo in the URL helper trailing slash comment

## Verification
- pnpm --filter web lint
- pnpm --filter web typecheck
