### PR TITLE
test(web): cover effect action bridge

### DIFF
--- a/apps/web/src/sometest.test.ts
+++ b/apps/web/src/sometest.test.ts
@@ -1,5 +1,16 @@
 import { expect, test } from 'vitest';
+import { Effect } from 'effect';
+import { runEffectInAction } from './utils/effect-bridge';
+import { ValidationError } from './utils/effect-errors';
 
-test('fake test', () => {
-  expect(true).toBe(true);
+test('runEffectInAction resolves successful effects', async () => {
+  await expect(runEffectInAction(Effect.succeed('ok'))).resolves.toBe('ok');
+});
+
+test('runEffectInAction throws app error messages', async () => {
+  await expect(
+    runEffectInAction(
+      Effect.fail(new ValidationError({ message: 'Name is required' }))
+    )
+  ).rejects.toThrow('Name is required');
 });

--- a/apps/web/src/utils/effect-bridge.ts
+++ b/apps/web/src/utils/effect-bridge.ts
@@ -1,4 +1,4 @@
-import { Effect, Exit } from 'effect';
+import { Cause, Effect, Exit, Option } from 'effect';
 import { AppError } from './effect-errors';
 
 /**
@@ -29,13 +29,9 @@ export async function runEffectInAction<A, E extends AppError>(
   const exit = await Effect.runPromiseExit(effect);
 
   if (Exit.isFailure(exit)) {
-    // Extract the error from the Cause
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const failure = exit.cause as any;
-    const appError =
-      failure._tag === 'Fail'
-        ? (failure.error as E)
-        : new Error('Unknown error');
+    const appError = Option.getOrElse(Cause.failureOption(exit.cause), () => {
+      return new Error('Unknown error');
+    });
 
     // Throw a standard Error for next-safe-action to catch
     throw new Error(


### PR DESCRIPTION
## Summary
- replace manual Effect Cause inspection with typed Cause.failureOption extraction
- add focused unit tests for runEffectInAction success and app-error failure paths

## Verification
- pnpm --filter web test
- pnpm --filter web typecheck
- pnpm --filter web lint