### PR TITLE
[codex] use env site url for sitemap

### DIFF
--- a/apps/web/next-sitemap.config.cjs
+++ b/apps/web/next-sitemap.config.cjs
@@ -1,5 +1,14 @@
 /** @type {import('next-sitemap').IConfig} */
+function getSiteUrl() {
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ??
+    process.env.NEXT_PUBLIC_VERCEL_URL ??
+    'https://my-awesome-saas.com';
+
+  return siteUrl.startsWith('http') ? siteUrl : `https://${siteUrl}`;
+}
+
 module.exports = {
-  siteUrl: 'https://my-awesome-saas.com', // FIXME: Change to your production URL
+  siteUrl: getSiteUrl(),
   generateRobotsTxt: true,
 };


### PR DESCRIPTION
## Summary
- Replace the hard-coded sitemap URL placeholder with the same env-driven site URL convention the app already uses.
- Preserve the existing fallback URL so builds still work if no env override is present.

## Validation
- `node -e "const cfg=require('./apps/web/next-sitemap.config.cjs'); console.log(cfg.siteUrl)"`
- `pnpm --filter web test`
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
