### PR TITLE
fix(web): point login image to existing asset

### DIFF
--- a/apps/web/src/app/(auth-pages)/login/NewLogin.tsx
+++ b/apps/web/src/app/(auth-pages)/login/NewLogin.tsx
@@ -97,8 +97,8 @@ export function NewLoginPage() {
       </div>
       <div className="w-1/2 h-screen">
         <img
-          src="/placeholder.svg"
-          alt="Background Image"
+          src="/mockups/placeholder.jpeg"
+          alt="Login illustration"
           width={1200}
           height={800}
           className="object-cover w-full h-full"


### PR DESCRIPTION
## Summary\n- Replace the broken /placeholder.svg reference on the login page with the existing /mockups/placeholder.jpeg asset.\n- Keep the rest of the page unchanged.\n\n## Verification\n- pnpm --filter web test\n- pnpm --filter web typecheck