### PR TITLE
test(web): scope home CTA selector

### DIFF
--- a/apps/web/e2e/anon/public-pages.spec.ts
+++ b/apps/web/e2e/anon/public-pages.spec.ts
@@ -9,7 +9,7 @@ test.describe.parallel('Anonymous user public pages', () => {
       page.getByRole('heading', { name: /build your.+saas product.+faster/i })
     ).toBeVisible();
     await expect(
-      page.getByRole('link', { name: /get started/i }).first()
+      page.getByRole('main').getByRole('link', { name: /get started/i })
     ).toBeVisible();
   });
 


### PR DESCRIPTION
Scope the home-page Playwright assertion to <main> so it targets the hero CTA instead of the header link.\n\nVerification:\n- Browser check confirmed 2 total 'Get Started' links and 1 inside <main>.\n-  passed.