### PR TITLE
[codex] align aspect ratio primitive

### DIFF
--- a/apps/web/src/components/ui/aspect-ratio.tsx
+++ b/apps/web/src/components/ui/aspect-ratio.tsx
@@ -1,7 +1,13 @@
 "use client"
 
+import * as React from "react"
 import * as AspectRatioPrimitive from "@radix-ui/react-aspect-ratio"
 
 const AspectRatio = AspectRatioPrimitive.Root
+type AspectRatioProps = React.ComponentPropsWithoutRef<
+  typeof AspectRatioPrimitive.Root
+>
 
-export { AspectRatio }
+AspectRatio.displayName = AspectRatioPrimitive.Root.displayName
+
+export { AspectRatio, type AspectRatioProps }


### PR DESCRIPTION
### What changed
- Added a `displayName` and exported props type to [`apps/web/src/components/ui/aspect-ratio.tsx`](/Users/bhargavponnapalli/.codex/worktrees/7346/nextbase-nextjs-supabase-starter/apps/web/src/components/ui/aspect-ratio.tsx).
- This matches the surrounding UI primitive wrappers and improves devtools/type ergonomics without changing runtime behavior.

### Validation
- `pnpm --filter web typecheck`
- `pnpm --filter web test`