### PR TITLE
docs: fix env setup paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ pnpm install
 ### 2. Configure environment
 Copy the examples and fill in your Supabase project details:
 ```bash
-cp .env.local.example apps/web/.env.local
-cp .env.development.local.example apps/web/.env.development.local
+cp .env.local.example .env.local
+cp .env.development.local.example .env.development.local
 ```
 
 Required variables:


### PR DESCRIPTION
## Summary\n- Correct the quick-start env copy commands to use the repo-root example files.\n\n## Verification\n- pnpm lint