### PR TITLE
[codex] forward auth button props

### DIFF
--- a/apps/web/src/components/Auth/EmailAndPassword.test.tsx
+++ b/apps/web/src/components/Auth/EmailAndPassword.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+
+import { EmailAndPassword } from './EmailAndPassword';
+
+test('EmailAndPassword forwards button props to the submit button', () => {
+  render(
+    <EmailAndPassword
+      isLoading
+      onSubmit={() => {}}
+      view="sign-in"
+      className="max-w-xs"
+      data-testid="login-submit"
+    />
+  );
+
+  const submitButton = screen.getByTestId('login-submit');
+
+  expect(submitButton.tagName).toBe('BUTTON');
+  expect(submitButton).toHaveProperty('type', 'submit');
+  expect(submitButton).toHaveProperty('disabled', true);
+  expect(submitButton.className).toContain('w-full');
+  expect(submitButton.className).toContain('max-w-xs');
+});

--- a/apps/web/src/components/Auth/EmailAndPassword.tsx
+++ b/apps/web/src/components/Auth/EmailAndPassword.tsx
@@ -10,16 +10,19 @@ import { Lock, Mail } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import type { ComponentProps } from 'react';
+import { cn } from '@/lib/utils';
 
 export const EmailAndPassword = ({
   onSubmit,
   view,
   isLoading,
+  className,
+  ...buttonProps
 }: {
   onSubmit: (data: { email: string; password: string }) => void;
   view: 'sign-in' | 'sign-up';
   isLoading: boolean;
-} & ComponentProps<typeof Button>) => {
+} & Omit<ComponentProps<typeof Button>, 'children' | 'type'>) => {
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
 
@@ -98,7 +101,12 @@ export const EmailAndPassword = ({
           ) : null}
         </div>
         <div className="space-y-2">
-          <Button disabled={isLoading} type="submit" className="w-full">
+          <Button
+            {...buttonProps}
+            disabled={isLoading}
+            type="submit"
+            className={cn('w-full', className)}
+          >
             {isLoading ? (
               <>
                 <Spinner className="h-4 w-4 mr-2" />

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig({
     plugins: [react()],
+    resolve: {
+        alias: {
+            '@': fileURLToPath(new URL('./src', import.meta.url)),
+        },
+    },
     test: {
         environment: 'jsdom',
     },


### PR DESCRIPTION
## What changed
- Forward button props from `EmailAndPassword` instead of dropping them.
- Merge caller-provided `className` with the default full-width button styling.
- Add a focused unit test for prop forwarding.
- Teach Vitest to resolve the repo's `@/` alias so component tests can import app code.

## Validation
- `pnpm --dir apps/web typecheck`
- `pnpm --filter web exec vitest run --root src components/Auth/EmailAndPassword.test.tsx`
- `pnpm --dir apps/web exec oxlint src/components/Auth/EmailAndPassword.tsx src/components/Auth/EmailAndPassword.test.tsx vitest.config.ts`
