### PR TITLE
test(web): isolate EmailAndPassword auth form tests

### DIFF
--- a/apps/web/src/components/Auth/EmailAndPassword.test.tsx
+++ b/apps/web/src/components/Auth/EmailAndPassword.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen } from '@testing-library/react';
-import { expect, test } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, expect, test } from 'vitest';
 
 import { EmailAndPassword } from './EmailAndPassword';
+
+afterEach(cleanup);
 
 test('EmailAndPassword forwards button props to the submit button', () => {
   render(
@@ -21,4 +23,23 @@ test('EmailAndPassword forwards button props to the submit button', () => {
   expect(submitButton).toHaveProperty('disabled', true);
   expect(submitButton.className).toContain('w-full');
   expect(submitButton.className).toContain('max-w-xs');
+});
+
+test('EmailAndPassword renders the sign-up variant without the forgot-password link', () => {
+  render(
+    <EmailAndPassword
+      isLoading={false}
+      onSubmit={() => {}}
+      view="sign-up"
+    />
+  );
+
+  screen.getByRole('button', { name: 'Sign up' });
+  expect(
+    screen.queryByRole('link', { name: /forgot your password\?/i })
+  ).toBeNull();
+  expect(
+    screen.getByRole('link', { name: /already have an account\? log in/i })
+      .getAttribute('href')
+  ).toBe('/login');
 });


### PR DESCRIPTION
Adds RTL cleanup between EmailAndPassword tests and covers the sign-up variant so the auth form assertions stay isolated and reliable.

Verified with: pnpm --filter web test -- src/components/Auth/EmailAndPassword.test.tsx