### PR TITLE
chore(web): rename effect bridge tests

### DIFF
--- a/apps/web/src/utils/effect-bridge.test.ts
+++ b/apps/web/src/utils/effect-bridge.test.ts
@@ -1,7 +1,8 @@
-import { expect, test } from 'vitest';
 import { Effect } from 'effect';
-import { getErrorMessage, runEffectInAction } from './utils/effect-bridge';
-import { ValidationError } from './utils/effect-errors';
+import { expect, test } from 'vitest';
+
+import { getErrorMessage, runEffectInAction } from './effect-bridge';
+import { ValidationError } from './effect-errors';
 
 test('runEffectInAction resolves successful effects', async () => {
   await expect(runEffectInAction(Effect.succeed('ok'))).resolves.toBe('ok');


### PR DESCRIPTION
## Summary
- rename the placeholder test file to `apps/web/src/utils/effect-bridge.test.ts`
- keep the effect-bridge coverage colocated with the module it exercises

## Verification
- `pnpm --filter web test`
