### PR TITLE
[codex] clarify proxy matcher comment

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -17,11 +17,10 @@ export async function proxy(request: NextRequest) {
 export const config = {
   matcher: [
     /*
-     * Match all request paths except for the ones starting with:
+     * Match all request paths except for static assets and the Next.js image pipeline.
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
-     * Feel free to modify this pattern to include more paths.
      */
     '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico)$).*)',
   ],


### PR DESCRIPTION
## Summary
- Clarify the proxy matcher comment in `apps/web/src/proxy.ts`
- Remove the stale template-style line that suggested modifying the pattern without context

## Verification
- `./node_modules/.bin/oxlint src/`
- `./node_modules/.bin/tsc --noEmit`
