### PR TITLE
test(web): poll inbox immediately

### DIFF
--- a/apps/web/e2e/_helpers/login-user.helper.ts
+++ b/apps/web/e2e/_helpers/login-user.helper.ts
@@ -16,8 +16,11 @@ async function getLatestEmailForAddress(emailAddress: string): Promise<InbucketM
   const requestContext = await request.newContext();
 
   try {
-    for (let i = 0; i < 20; i++) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+    for (let attempt = 0; attempt < 20; attempt++) {
+      if (attempt > 0) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+
       const response = await requestContext
         .get(`${INBUCKET_URL}/api/v1/search?query=${mailbox}&limit=20`)
         .catch(() => null);

--- a/apps/web/e2e/_helpers/signup.helper.ts
+++ b/apps/web/e2e/_helpers/signup.helper.ts
@@ -16,8 +16,11 @@ async function getLatestEmailForAddress(emailAddress: string): Promise<InbucketM
   const requestContext = await request.newContext();
 
   try {
-    for (let i = 0; i < 20; i++) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+    for (let attempt = 0; attempt < 20; attempt++) {
+      if (attempt > 0) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+
       const response = await requestContext
         .get(`${INBUCKET_URL}/api/v1/search?query=${mailbox}&limit=20`)
         .catch(() => null);


### PR DESCRIPTION
## Summary\n- check the Inbucket mailbox immediately before polling in the login and signup helpers\n- reduce unnecessary delay in auth setup while keeping the same retry window\n\n## Verification\n- pnpm --filter web typecheck\n- pnpm --filter web test