### PR TITLE
[codex] fix(web): respect disabled button props

### DIFF
--- a/apps/web/src/components/Auth/EmailAndPassword.test.tsx
+++ b/apps/web/src/components/Auth/EmailAndPassword.test.tsx
@@ -8,10 +8,11 @@ afterEach(cleanup);
 test('EmailAndPassword forwards button props to the submit button', () => {
   render(
     <EmailAndPassword
-      isLoading
+      isLoading={false}
       onSubmit={() => {}}
       view="sign-in"
       className="max-w-xs"
+      disabled
       data-testid="login-submit"
     />
   );
@@ -23,6 +24,22 @@ test('EmailAndPassword forwards button props to the submit button', () => {
   expect(submitButton).toHaveProperty('disabled', true);
   expect(submitButton.className).toContain('w-full');
   expect(submitButton.className).toContain('max-w-xs');
+});
+
+test('EmailAndPassword still disables the submit button while loading', () => {
+  render(
+    <EmailAndPassword
+      isLoading
+      onSubmit={() => {}}
+      view="sign-in"
+      data-testid="loading-submit"
+    />
+  );
+
+  const submitButton = screen.getByTestId('loading-submit');
+
+  expect(submitButton).toHaveProperty('disabled', true);
+  expect(screen.getByText('Loading...').textContent).toBe('Loading...');
 });
 
 test('EmailAndPassword renders the sign-up variant without the forgot-password link', () => {

--- a/apps/web/src/components/Auth/EmailAndPassword.tsx
+++ b/apps/web/src/components/Auth/EmailAndPassword.tsx
@@ -103,7 +103,7 @@ export const EmailAndPassword = ({
         <div className="space-y-2">
           <Button
             {...buttonProps}
-            disabled={isLoading}
+            disabled={isLoading || buttonProps.disabled}
             type="submit"
             className={cn('w-full', className)}
           >


### PR DESCRIPTION
Preserve caller-supplied disabled state on the auth submit button while still disabling it during loading.

Validation:
- `pnpm -C apps/web exec vitest run src/components/Auth/EmailAndPassword.test.tsx`
- `pnpm -C apps/web typecheck`
