### PR TITLE
Tighten magic-link redirect checks

### DIFF
--- a/apps/web/e2e/_helpers/login-user.helper.ts
+++ b/apps/web/e2e/_helpers/login-user.helper.ts
@@ -89,5 +89,5 @@ export async function loginUserHelper({
   if (!link) throw new Error('Could not find login link in email');
 
   await page.goto(link);
-  await page.waitForURL(/dashboard|app/, { timeout: 30000 });
+  await page.waitForURL(/\/dashboard(?:[/?#]|$)/, { timeout: 30000 });
 }

--- a/apps/web/e2e/_helpers/signup.helper.ts
+++ b/apps/web/e2e/_helpers/signup.helper.ts
@@ -91,5 +91,5 @@ export async function signupUserHelper({
   if (!link) throw new Error('Could not find confirmation link in email');
 
   await page.goto(link);
-  await page.waitForURL(/dashboard|app/, { timeout: 30000 });
+  await page.waitForURL(/\/dashboard(?:[/?#]|$)/, { timeout: 30000 });
 }


### PR DESCRIPTION
## Summary\n- Tighten the magic-link post-auth URL matcher in both e2e helpers so it only accepts the dashboard route.\n\n## Verification\n- pnpm -C apps/web test\n- pnpm -C apps/web lint\n- pnpm -C apps/web typecheck