### PR TITLE
docs(web): remove stale layout comment

### DIFF
--- a/apps/web/src/app/DynamicLayoutProviders.tsx
+++ b/apps/web/src/app/DynamicLayoutProviders.tsx
@@ -11,15 +11,7 @@ function CustomerToaster() {
   return <SonnerToaster richColors theme={currentTheme} />;
 }
 
-/**
- * This is a wrapper for the app that provides the supabase client, the router event wrapper
- * the react-query client, supabase listener, and the navigation progress bar.
- *
- * The listener is used to listen for changes to the user's session and update the UI accordingly.
- */
 export function DynamicLayoutProviders({
-  // Layouts must accept a children prop.
-  // This will be populated with nested layouts or pages
   children,
 }: {
   children: React.ReactNode;


### PR DESCRIPTION
## Summary\n- remove a stale description from DynamicLayoutProviders so it matches the current wrapper responsibilities\n\n## Verification\n- pnpm --filter web test\n- pnpm --filter web lint