### PR TITLE
[codex] tighten effect error message typing

### DIFF
--- a/apps/web/src/utils/effect-bridge.test.ts
+++ b/apps/web/src/utils/effect-bridge.test.ts
@@ -16,6 +16,12 @@ test('runEffectInAction throws app error messages', async () => {
   ).rejects.toThrow('Name is required');
 });
 
+test('runEffectInAction falls back when an app error message is empty', async () => {
+  await expect(
+    runEffectInAction(Effect.fail(new ValidationError({ message: '' })))
+  ).rejects.toThrow('An error occurred while processing the request');
+});
+
 test('getErrorMessage includes validation field names', () => {
   expect(
     getErrorMessage(

--- a/apps/web/src/utils/effect-bridge.ts
+++ b/apps/web/src/utils/effect-bridge.ts
@@ -1,6 +1,19 @@
 import { Cause, Effect, Exit, Option } from 'effect';
 import { AppError } from './effect-errors';
 
+function extractErrorMessage(error: unknown): string {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
+    return error.message;
+  }
+
+  return '';
+}
+
 /**
  * Runs an Effect within a next-safe-action handler, converting it to a Promise
  * and throwing an Error if the Effect fails.
@@ -34,12 +47,8 @@ export async function runEffectInAction<A, E extends AppError>(
     });
 
     // Throw a standard Error for next-safe-action to catch
-    throw new Error(
-      typeof appError === 'object' && appError !== null && 'message' in appError
-        ? (appError.message as string) ||
-        'An error occurred while processing the request'
-        : 'An error occurred while processing the request'
-    );
+    const message = extractErrorMessage(appError);
+    throw new Error(message || 'An error occurred while processing the request');
   }
 
   return exit.value;


### PR DESCRIPTION
Added a small type-safe helper in `apps/web/src/utils/effect-bridge.ts` so `runEffectInAction` extracts error messages without an unsafe string cast.

Added one focused unit test that verifies the generic fallback message when an app error has an empty message.

Validation: `pnpm --filter web test` and `pnpm --filter web typecheck`
