### PR TITLE
[codex] tighten setup env copy loop

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,15 +4,17 @@ set -euo pipefail
 # Stop any stale Supabase containers from a previous run to avoid port-bind failures.
 ( cd apps/database && pnpm supabase stop --no-backup 2>/dev/null || true ) || true
 
-# Copy .env*.example files to their .env counterparts if missing.
-# Covers repo root, apps/*, and packages/*.
-while IFS= read -r ex; do
+# Copy root .env*.example files to their .env counterparts if missing.
+for ex in .env.local.example .env.development.local.example; do
+  if [ ! -f "$ex" ]; then
+    continue
+  fi
   target="${ex%.example}"
   if [ ! -f "$target" ]; then
     cp "$ex" "$target"
     echo "Created $target"
   fi
-done < <(find . \( -name ".env.local.example" -o -name ".env.development.local.example" \) -not -path "*/node_modules/*" -not -path "*/.git/*")
+done
 
 # Install dependencies.
 pnpm i


### PR DESCRIPTION
## What changed
- Tightened `setup.sh` so it only copies the two root env example files the repo actually ships.
- Removed the repo-wide `find` scan and the stale comment about nested example files.

## Why
- The repository rules say the env example files live at the repo root.
- The narrower loop is simpler and avoids unnecessary filesystem traversal during setup.

## Validation
- `bash -n setup.sh`
- Isolated smoke test of the env-copy loop in a temp directory
- `git diff --check`
