### PR TITLE
[codex] type supabase browser client

### DIFF
--- a/apps/web/src/supabase-clients/client.ts
+++ b/apps/web/src/supabase-clients/client.ts
@@ -2,7 +2,7 @@
 
 import { createBrowserClient } from '@supabase/ssr';
 
-export function createClient() {
+export function createClient(): ReturnType<typeof createBrowserClient> {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL,
     process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY


### PR DESCRIPTION
## What changed

- Added an explicit return type to `createClient()` in the Supabase browser client.

## Why

- Keeps the helper type-safe without changing runtime behavior.

## Verification

- `pnpm --filter web typecheck`
