### PR TITLE
chore(web): stabilize toast listener effect

### DIFF
--- a/apps/web/src/hooks/use-toast.ts
+++ b/apps/web/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- Keep the toast hook subscription stable instead of re-running it on every state change.

## Verification
- pnpm --filter web typecheck
- pnpm --filter web test