### PR TITLE
Fix validation error fallback messaging

### DIFF
--- a/apps/web/src/utils/effect-bridge.test.ts
+++ b/apps/web/src/utils/effect-bridge.test.ts
@@ -29,3 +29,9 @@ test('getErrorMessage includes validation field names', () => {
     )
   ).toBe('email: Email is required');
 });
+
+test('getErrorMessage falls back for fielded validation errors without a message', () => {
+  expect(
+    getErrorMessage(new ValidationError({ field: 'email', message: '' }))
+  ).toBe('email: Validation failed');
+});

--- a/apps/web/src/utils/effect-bridge.ts
+++ b/apps/web/src/utils/effect-bridge.ts
@@ -108,9 +108,11 @@ export function getErrorMessage(error: AppError): string {
     case 'NotFoundError':
       return error.message || `${error.resource} not found`;
     case 'ValidationError':
-      return error.field
-        ? `${error.field}: ${error.message}`
-        : error.message || 'Validation failed';
+      if (error.field) {
+        return `${error.field}: ${error.message || 'Validation failed'}`;
+      }
+
+      return error.message || 'Validation failed';
     case 'AuthenticationError':
       return error.message || 'Authentication failed';
     case 'NetworkError':


### PR DESCRIPTION
## Summary\n- improve Effect validation error formatting when a field is present but the message is empty\n- add a unit test covering the fallback\n\n## Verification\n- pnpm --filter web test -- src/utils/effect-bridge.test.ts\n- pnpm --filter web typecheck