### PR TITLE
chore(web): drop unused login query prop

### DIFF
--- a/apps/web/src/app/(auth-pages)/login/Login.tsx
+++ b/apps/web/src/app/(auth-pages)/login/Login.tsx
@@ -24,10 +24,8 @@ import { toast } from 'sonner';
 
 export function Login({
   next,
-  nextActionType: _nextActionType,
 }: {
   next?: string;
-  nextActionType?: string;
 }) {
   const [emailSentSuccessMessage, setEmailSentSuccessMessage] = useState<
     string | null

--- a/apps/web/src/app/(auth-pages)/login/page.tsx
+++ b/apps/web/src/app/(auth-pages)/login/page.tsx
@@ -4,7 +4,6 @@ import { Login } from './Login';
 
 const SearchParamsSchema = z.object({
   next: z.string().optional(),
-  nextActionType: z.string().optional(),
 });
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
@@ -13,8 +12,8 @@ async function LoginWrapper(props: {
   searchParams: SearchParams;
 }) {
   const searchParams = await props.searchParams;
-  const { next, nextActionType } = SearchParamsSchema.parse(searchParams);
-  return <Login next={next} nextActionType={nextActionType} />;
+  const { next } = SearchParamsSchema.parse(searchParams);
+  return <Login next={next} />;
 }
 
 export default async function LoginPage(props: {


### PR DESCRIPTION
Removes the unused `nextActionType` login query param plumbing from the login page and component. Verified with `pnpm --filter web typecheck`.