### PR TITLE
[codex] normalize site url helper

### DIFF
--- a/apps/web/src/utils/helpers.test.ts
+++ b/apps/web/src/utils/helpers.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, expect, test } from 'vitest';
+
+import { getURL, toSiteURL } from './helpers';
+
+const originalEnv = {
+  NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
+  NEXT_PUBLIC_VERCEL_URL: process.env.NEXT_PUBLIC_VERCEL_URL,
+};
+
+function restoreEnv(key: 'NEXT_PUBLIC_SITE_URL' | 'NEXT_PUBLIC_VERCEL_URL', value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+
+  process.env[key] = value;
+}
+
+afterEach(() => {
+  restoreEnv('NEXT_PUBLIC_SITE_URL', originalEnv.NEXT_PUBLIC_SITE_URL);
+  restoreEnv('NEXT_PUBLIC_VERCEL_URL', originalEnv.NEXT_PUBLIC_VERCEL_URL);
+});
+
+test('getURL normalizes a configured site URL', () => {
+  process.env.NEXT_PUBLIC_SITE_URL = 'example.com';
+  delete process.env.NEXT_PUBLIC_VERCEL_URL;
+
+  expect(getURL()).toBe('https://example.com/');
+});
+
+test('getURL falls back to the local dev port', () => {
+  delete process.env.NEXT_PUBLIC_SITE_URL;
+  delete process.env.NEXT_PUBLIC_VERCEL_URL;
+
+  expect(getURL()).toBe('http://localhost:3000/');
+});
+
+test('toSiteURL joins paths against the normalized base URL', () => {
+  process.env.NEXT_PUBLIC_SITE_URL = 'https://example.com/app';
+  delete process.env.NEXT_PUBLIC_VERCEL_URL;
+
+  expect(toSiteURL('/auth/callback')).toBe('https://example.com/app/auth/callback');
+});

--- a/apps/web/src/utils/helpers.ts
+++ b/apps/web/src/utils/helpers.ts
@@ -9,7 +9,7 @@ export const getURL = (): string => {
   // Make sure to include `https://` when not localhost.
   url = url.startsWith('http') ? url : `https://${url}`;
   // Make sure to include a trailing `/`.
-  url = url.charAt(url.length - 1) === '/' ? url : `${url}/`;
+  url = url.endsWith('/') ? url : `${url}/`;
   return url;
 };
 


### PR DESCRIPTION
## What changed
- Normalized the trailing slash check in `getURL()` to use `endsWith('/')`.
- Added unit coverage for configured, local fallback, and joined site URLs.

## Why
- Keeps the helper behavior explicit and locked down with a small regression test.

## Verification
- `pnpm --filter web test -- helpers.test.ts`
- `pnpm --filter web typecheck`
