### PR TITLE
chore(web): normalize auth email placeholder

### DIFF
--- a/apps/web/src/components/Auth/Email.tsx
+++ b/apps/web/src/components/Auth/Email.tsx
@@ -64,7 +64,7 @@ export const Email = ({
               disabled={isLoading}
               onChange={(event) => setEmail(event.target.value)}
               autoComplete={'email'}
-              placeholder="placeholder@email.com"
+              placeholder="email@example.com"
               required
             />
           </div>

--- a/apps/web/src/components/Auth/EmailAndPassword.test.tsx
+++ b/apps/web/src/components/Auth/EmailAndPassword.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, expect, test } from 'vitest';
 
 import { EmailAndPassword } from './EmailAndPassword';
+import { Email } from './Email';
 
 afterEach(cleanup);
 
@@ -59,4 +60,34 @@ test('EmailAndPassword renders the sign-up variant without the forgot-password l
     screen.getByRole('link', { name: /already have an account\? log in/i })
       .getAttribute('href')
   ).toBe('/login');
+});
+
+test('auth email fields use a standard example placeholder', () => {
+  const emailForm = render(
+    <Email
+      isLoading={false}
+      onSubmit={() => {}}
+      view="sign-in"
+    />
+  );
+
+  expect(emailForm.getByLabelText('Email address')).toHaveProperty(
+    'placeholder',
+    'email@example.com'
+  );
+
+  emailForm.unmount();
+
+  const passwordForm = render(
+    <EmailAndPassword
+      isLoading={false}
+      onSubmit={() => {}}
+      view="sign-in"
+    />
+  );
+
+  expect(passwordForm.getByLabelText('Email address')).toHaveProperty(
+    'placeholder',
+    'email@example.com'
+  );
 });

--- a/apps/web/src/components/Auth/EmailAndPassword.tsx
+++ b/apps/web/src/components/Auth/EmailAndPassword.tsx
@@ -54,7 +54,7 @@ export const EmailAndPassword = ({
                 disabled={isLoading}
                 value={email}
                 data-strategy="email-password"
-                placeholder="placeholder@email.com"
+                placeholder="email@example.com"
                 onChange={(event) => setEmail(event.target.value)}
                 autoComplete={'email'}
                 required


### PR DESCRIPTION
## Summary\n- normalize the auth email placeholder to a standard example address\n- cover both auth email inputs with a focused unit test\n\n## Verification\n- pnpm --filter web test -- components/Auth/EmailAndPassword.test.tsx\n- pnpm --filter web lint