### PR TITLE
refactor(web): restyle navbar with shadcn/ui

### DIFF
--- a/.agents/skills/nextbase-frontend-smoke-test/SKILL.md
+++ b/.agents/skills/nextbase-frontend-smoke-test/SKILL.md
@@ -44,3 +44,9 @@ Use this skill to run a fast end-to-end smoke test of `apps/web` when upgrading 
 - Home page visibly shows the hero `ShinyText` heading, `BlurText` description, and `SpotlightCard` CTA.
 - Login page visibly shows the `ShinyText` `Login to NextBase` heading and `Password` / `Magic Link` / `Social Login` tabs.
 - `pnpm --filter=web typecheck`, `pnpm --filter=web lint`, and `pnpm --filter=web build` exit 0.
+
+## Navbar / Navigation Smoke Testing
+- Maximize the browser before desktop tests; use `wmctrl -r :ACTIVE: -b remove,maximized_vert,maximized_horz && wmctrl -r :ACTIVE: -e 0,0,0,500,900` for a narrow mobile viewport.
+- Desktop assertions: logo + "Nextbase" text, `Home`, `About`, `Features` links, theme toggle, `Sign in`, `Get Started`; active link uses `bg-accent text-foreground`; `Features` scrolls to `id="features"`.
+- Mobile assertions: hamburger `Menu` button opens a right-side shadcn `Sheet` titled "Menu" with the same links, theme row, and auth buttons; navigating inside the sheet closes it.
+- Theme toggle watch-out: `next-themes` 0.4 defaults to `attribute="data-theme"`, but Tailwind v4 in this repo uses `@custom-variant dark (&:is(.dark *))`. If `ThemeProvider` is not given `attribute="class"`, clicking `ModeToggle` updates `data-theme` and `localStorage` but the UI stays light. Verify by checking the `<html>` class and background color, not just `localStorage`.

--- a/apps/web/src/app/(external-pages)/home-features.tsx
+++ b/apps/web/src/app/(external-pages)/home-features.tsx
@@ -13,7 +13,7 @@ interface HomeFeaturesProps {
 
 export function HomeFeatures({ features }: HomeFeaturesProps) {
   return (
-    <section className="py-20 px-4">
+    <section id="features" className="py-20 px-4">
       <div className="max-w-5xl mx-auto">
         <div className="text-center mb-12">
           <h2 className="text-3xl font-bold tracking-tight">Everything you need</h2>

--- a/apps/web/src/app/(external-pages)/layout.tsx
+++ b/apps/web/src/app/(external-pages)/layout.tsx
@@ -6,7 +6,7 @@ export default function ExternalLayout({ children }: { children: ReactNode }) {
   return (
     <div className="flex flex-col min-h-screen">
       <Navbar />
-      <main className="flex-1">
+      <main className="flex-1 pt-20">
         {children}
       </main>
       <Footer />

--- a/apps/web/src/app/DynamicLayoutProviders.tsx
+++ b/apps/web/src/app/DynamicLayoutProviders.tsx
@@ -17,7 +17,12 @@ export function DynamicLayoutProviders({
   children: React.ReactNode;
 }) {
   return (
-    <ThemeProvider enableSystem themes={['light', 'dark']} defaultTheme="light">
+    <ThemeProvider
+      attribute="class"
+      enableSystem
+      themes={['light', 'dark']}
+      defaultTheme="light"
+    >
       {children}
       <Suspense>
         <ProgressBar

--- a/apps/web/src/app/MobileNavigation.tsx
+++ b/apps/web/src/app/MobileNavigation.tsx
@@ -28,15 +28,18 @@ export function MobileNavigation({ items }: MobileNavigationProps) {
         <Button
           variant="ghost"
           size="icon"
-          className="md:hidden"
+          className="h-9 w-9 rounded-full md:hidden"
           aria-label="Open navigation"
         >
           <Menu className="h-5 w-5" />
         </Button>
       </SheetTrigger>
-      <SheetContent side="right" className="w-[280px] sm:w-[320px]">
+      <SheetContent
+        side="right"
+        className="w-[280px] rounded-l-2xl bg-background/95 backdrop-blur-xl sm:w-[320px]"
+      >
         <SheetHeader>
-          <SheetTitle className="text-left">Menu</SheetTitle>
+          <SheetTitle className="text-left text-base">Menu</SheetTitle>
         </SheetHeader>
         <nav className="mt-6 flex flex-col gap-1" aria-label="Mobile">
           {items.map(({ label, href }) => (
@@ -44,22 +47,31 @@ export function MobileNavigation({ items }: MobileNavigationProps) {
               key={href}
               href={href}
               onClick={() => setOpen(false)}
-              className="flex h-10 items-center rounded-md px-4 text-base font-medium hover:bg-accent"
+              className="flex h-10 items-center rounded-lg px-3 text-base font-medium transition-colors hover:bg-muted"
             >
               {label}
             </NavLink>
           ))}
         </nav>
         <Separator className="my-4" />
-        <div className="flex flex-col gap-3 px-4">
-          <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between rounded-lg px-3 py-2 hover:bg-muted">
             <span className="text-sm text-muted-foreground">Theme</span>
-            <ModeToggle />
+            <ModeToggle className="h-8 w-8" />
           </div>
-          <Button asChild variant="ghost" onClick={() => setOpen(false)}>
+          <Button
+            asChild
+            variant="ghost"
+            onClick={() => setOpen(false)}
+            className="justify-start rounded-lg px-3 font-medium"
+          >
             <Link href="/login">Sign in</Link>
           </Button>
-          <Button asChild onClick={() => setOpen(false)}>
+          <Button
+            asChild
+            onClick={() => setOpen(false)}
+            className="rounded-full font-medium"
+          >
             <Link href="/sign-up">Get Started</Link>
           </Button>
         </div>

--- a/apps/web/src/app/MobileNavigation.tsx
+++ b/apps/web/src/app/MobileNavigation.tsx
@@ -1,76 +1,69 @@
 'use client';
-import { ComponentProps, useState } from 'react';
+
+import { Menu } from 'lucide-react';
 import Link from 'next/link';
-import { Dialog } from '@headlessui/react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { ModeToggle } from '@/components/ui/mode-toggle';
+import { Separator } from '@/components/ui/separator';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
+import { NavLink } from './NavLink';
 
-function MenuIcon(props: ComponentProps<'svg'>) {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 24 24"
-      fill="none"
-      strokeWidth="2"
-      strokeLinecap="round"
-      {...props}
-    >
-      <path d="M4 7h16M4 12h16M4 17h16" />
-    </svg>
-  );
-}
+type MobileNavigationProps = {
+  items: { label: string; href: string }[];
+};
 
-function CloseIcon(props: ComponentProps<'svg'>) {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 24 24"
-      fill="none"
-      strokeWidth="2"
-      strokeLinecap="round"
-      {...props}
-    >
-      <path d="M5 5l14 14M19 5l-14 14" />
-    </svg>
-  );
-}
-
-export function MobileNavigation() {
-  const [isOpen, setIsOpen] = useState(false);
+export function MobileNavigation({ items }: MobileNavigationProps) {
+  const [open, setOpen] = useState(false);
 
   return (
-    <>
-      <button
-        type="button"
-        onClick={() => setIsOpen(true)}
-        className="relative"
-        aria-label="Open navigation"
-      >
-        <MenuIcon className="h-6 w-6 stroke-slate-500" />
-      </button>
-      <Dialog
-        open={isOpen}
-        onClose={setIsOpen}
-        className="fixed inset-0 z-50 flex items-start overflow-y-auto bg-slate-900/50 pr-10 backdrop-blur-sm lg:hidden"
-        aria-label="Navigation"
-      >
-        <Dialog.Panel className="min-h-full w-full max-w-xs bg-white px-4 pb-12 pt-5 dark:bg-slate-900 sm:px-6">
-          <div className="flex items-center">
-            <button
-              type="button"
-              onClick={() => setIsOpen(false)}
-              aria-label="Close navigation"
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="md:hidden"
+          aria-label="Open navigation"
+        >
+          <Menu className="h-5 w-5" />
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="w-[280px] sm:w-[320px]">
+        <SheetHeader>
+          <SheetTitle className="text-left">Menu</SheetTitle>
+        </SheetHeader>
+        <nav className="mt-6 flex flex-col gap-1" aria-label="Mobile">
+          {items.map(({ label, href }) => (
+            <NavLink
+              key={href}
+              href={href}
+              onClick={() => setOpen(false)}
+              className="flex h-10 items-center rounded-md px-4 text-base font-medium hover:bg-accent"
             >
-              <CloseIcon className="h-6 w-6 stroke-slate-500" />
-            </button>
-            <Link href="/" className="block" aria-label="Home page">
-              <img
-                src="https://usenextbase.com/logos/nextbase/Logo%2006.png"
-                className="h-9 block sm:h-9"
-                alt="Nextbase Logo"
-              />
-            </Link>
+              {label}
+            </NavLink>
+          ))}
+        </nav>
+        <Separator className="my-4" />
+        <div className="flex flex-col gap-3 px-4">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-muted-foreground">Theme</span>
+            <ModeToggle />
           </div>
-        </Dialog.Panel>
-      </Dialog>
-    </>
+          <Button asChild variant="ghost" onClick={() => setOpen(false)}>
+            <Link href="/login">Sign in</Link>
+          </Button>
+          <Button asChild onClick={() => setOpen(false)}>
+            <Link href="/sign-up">Get Started</Link>
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/apps/web/src/app/NavLink.tsx
+++ b/apps/web/src/app/NavLink.tsx
@@ -1,22 +1,35 @@
 'use client';
+
 import { cn } from '@/lib/utils';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { ComponentProps } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
+
+type NavLinkProps = {
+  href: string;
+  children: ReactNode;
+} & Omit<ComponentProps<typeof Link>, 'href' | 'children'>;
 
 export function NavLink({
   href,
+  className,
+  children,
   ...props
-}: {
-  href: string;
-} & ComponentProps<typeof Link>) {
+}: NavLinkProps) {
   const pathname = usePathname();
   const isActive = pathname === href;
+
   return (
     <Link
-      {...props}
       href={href}
-      className={cn(isActive ? 'font-bold text-blue-600' : 'font-medium')}
-    ></Link>
+      className={cn(
+        'text-sm font-medium transition-colors hover:text-foreground',
+        isActive ? 'text-foreground' : 'text-muted-foreground',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </Link>
   );
 }

--- a/apps/web/src/app/Navbar.tsx
+++ b/apps/web/src/app/Navbar.tsx
@@ -20,7 +20,7 @@ export default function Navbar() {
   return (
     <header className="fixed top-4 left-0 right-0 z-50 flex justify-center px-4">
       <nav
-        className="flex h-12 w-full max-w-2xl items-center justify-between rounded-full border border-border/50 bg-background/70 px-2 shadow-sm backdrop-blur-xl dark:bg-background/60"
+        className="flex h-12 w-full max-w-2xl items-center justify-between rounded-full border border-border/40 bg-muted/70 px-2 shadow-md ring-1 ring-border/10 backdrop-blur-2xl dark:bg-muted/60"
         aria-label="Global"
       >
         <Link href="/" className="flex items-center gap-2 px-2">

--- a/apps/web/src/app/Navbar.tsx
+++ b/apps/web/src/app/Navbar.tsx
@@ -50,7 +50,7 @@ export default function Navbar() {
                 className={cn(
                   'rounded-full text-sm font-medium',
                   isActive
-                    ? 'bg-muted text-foreground'
+                    ? 'text-foreground'
                     : 'text-muted-foreground hover:text-foreground'
                 )}
               >

--- a/apps/web/src/app/Navbar.tsx
+++ b/apps/web/src/app/Navbar.tsx
@@ -1,31 +1,88 @@
+'use client';
+
+import Image from 'next/image';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import {
+  NavigationMenu,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  navigationMenuTriggerStyle,
+} from '@/components/ui/navigation-menu';
 import { ModeToggle } from '@/components/ui/mode-toggle';
+import { cn } from '@/lib/utils';
+import { MobileNavigation } from './MobileNavigation';
+
+export const NAV_LINKS = [
+  { label: 'Home', href: '/' },
+  { label: 'About', href: '/about' },
+  { label: 'Features', href: '/#features' },
+];
 
 export default function Navbar() {
+  const pathname = usePathname();
+
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container flex h-14 max-w-screen-2xl items-center mx-auto px-4">
-        <div className="flex items-center gap-6 flex-1">
-          <Link href="/" className="flex items-center gap-2 font-bold text-lg">
-            <span className="text-primary">Nextbase</span>
-          </Link>
-          <nav className="hidden md:flex items-center gap-6 text-sm">
-            <Link href="/about" className="text-muted-foreground transition-colors hover:text-foreground">
-              About
-            </Link>
-          </nav>
-        </div>
+      <nav
+        className="container mx-auto flex h-14 items-center justify-between px-4 md:px-6"
+        aria-label="Global"
+      >
+        <Link href="/" className="flex items-center gap-2">
+          <Image
+            src="/logos/nextbase.png"
+            alt="Nextbase"
+            width={32}
+            height={32}
+            className="h-8 w-8 rounded-md object-contain"
+          />
+          <span className="text-lg font-bold text-foreground">Nextbase</span>
+        </Link>
+
+        <NavigationMenu className="hidden md:flex">
+          <NavigationMenuList>
+            {NAV_LINKS.map(({ label, href }) => {
+              const isActive =
+                pathname === href || (href !== '/' && pathname?.startsWith(href));
+              return (
+                <NavigationMenuItem key={href}>
+                  <NavigationMenuLink asChild>
+                    <Link
+                      href={href}
+                      className={cn(
+                        navigationMenuTriggerStyle(),
+                        isActive
+                          ? 'bg-accent text-foreground'
+                          : 'text-muted-foreground'
+                      )}
+                    >
+                      {label}
+                    </Link>
+                  </NavigationMenuLink>
+                </NavigationMenuItem>
+              );
+            })}
+          </NavigationMenuList>
+        </NavigationMenu>
+
         <div className="flex items-center gap-2">
           <ModeToggle />
-          <Button asChild variant="ghost" size="sm">
+          <Button
+            asChild
+            variant="ghost"
+            size="sm"
+            className="hidden md:inline-flex"
+          >
             <Link href="/login">Sign in</Link>
           </Button>
-          <Button asChild size="sm">
+          <Button asChild size="sm" className="hidden md:inline-flex">
             <Link href="/sign-up">Get Started</Link>
           </Button>
+          <MobileNavigation items={NAV_LINKS} />
         </div>
-      </div>
+      </nav>
     </header>
   );
 }

--- a/apps/web/src/app/Navbar.tsx
+++ b/apps/web/src/app/Navbar.tsx
@@ -4,13 +4,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
-import {
-  NavigationMenu,
-  NavigationMenuItem,
-  NavigationMenuLink,
-  NavigationMenuList,
-  navigationMenuTriggerStyle,
-} from '@/components/ui/navigation-menu';
 import { ModeToggle } from '@/components/ui/mode-toggle';
 import { cn } from '@/lib/utils';
 import { MobileNavigation } from './MobileNavigation';
@@ -25,59 +18,63 @@ export default function Navbar() {
   const pathname = usePathname();
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <header className="fixed top-4 left-0 right-0 z-50 flex justify-center px-4">
       <nav
-        className="container mx-auto flex h-14 items-center justify-between px-4 md:px-6"
+        className="flex h-12 w-full max-w-2xl items-center justify-between rounded-full border border-border/50 bg-background/70 px-2 shadow-sm backdrop-blur-xl dark:bg-background/60"
         aria-label="Global"
       >
-        <Link href="/" className="flex items-center gap-2">
+        <Link href="/" className="flex items-center gap-2 px-2">
           <Image
             src="/logos/nextbase.png"
             alt="Nextbase"
-            width={32}
-            height={32}
-            className="h-8 w-8 rounded-md object-contain"
+            width={28}
+            height={28}
+            className="h-7 w-7 rounded-md object-contain"
           />
-          <span className="text-lg font-bold text-foreground">Nextbase</span>
+          <span className="text-base font-semibold tracking-tight text-foreground">
+            Nextbase
+          </span>
         </Link>
 
-        <NavigationMenu className="hidden md:flex">
-          <NavigationMenuList>
-            {NAV_LINKS.map(({ label, href }) => {
-              const isActive =
-                pathname === href || (href !== '/' && pathname?.startsWith(href));
-              return (
-                <NavigationMenuItem key={href}>
-                  <NavigationMenuLink asChild>
-                    <Link
-                      href={href}
-                      className={cn(
-                        navigationMenuTriggerStyle(),
-                        isActive
-                          ? 'bg-accent text-foreground'
-                          : 'text-muted-foreground'
-                      )}
-                    >
-                      {label}
-                    </Link>
-                  </NavigationMenuLink>
-                </NavigationMenuItem>
-              );
-            })}
-          </NavigationMenuList>
-        </NavigationMenu>
+        <div className="hidden items-center gap-0.5 md:flex">
+          {NAV_LINKS.map(({ label, href }) => {
+            const isActive =
+              pathname === href ||
+              (href !== '/' && pathname?.startsWith(href.split('#')[0]));
+            return (
+              <Button
+                key={href}
+                asChild
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  'rounded-full text-sm font-medium',
+                  isActive
+                    ? 'bg-muted text-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                <Link href={href}>{label}</Link>
+              </Button>
+            );
+          })}
+        </div>
 
-        <div className="flex items-center gap-2">
-          <ModeToggle />
+        <div className="flex items-center gap-1">
+          <ModeToggle className="rounded-full" />
           <Button
             asChild
             variant="ghost"
             size="sm"
-            className="hidden md:inline-flex"
+            className="hidden rounded-full text-sm md:inline-flex"
           >
             <Link href="/login">Sign in</Link>
           </Button>
-          <Button asChild size="sm" className="hidden md:inline-flex">
+          <Button
+            asChild
+            size="sm"
+            className="hidden rounded-full text-sm md:inline-flex"
+          >
             <Link href="/sign-up">Get Started</Link>
           </Button>
           <MobileNavigation items={NAV_LINKS} />

--- a/apps/web/src/components/ui/mode-toggle.tsx
+++ b/apps/web/src/components/ui/mode-toggle.tsx
@@ -3,14 +3,16 @@
 import { Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
 
-export function ModeToggle() {
+export function ModeToggle({ className }: { className?: string }) {
   const { theme, setTheme } = useTheme();
 
   return (
     <Button
       variant="ghost"
       size="icon"
+      className={cn('rounded-full', className)}
       onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
     >
       <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />


### PR DESCRIPTION
Reworks the marketing navbar into a shadcn/ui-style floating glass pill instead of the previous full-width boxy header.

## What changed

- Replaced the sticky `container h-14 border-b` header with a centered, `rounded-full`, `max-w-2xl` pill that floats `fixed top-4`.
- The pill uses shadcn/ui `Button` links (`variant="ghost"`, `rounded-full`) so hover/active states stay rounded, not rectangular.
- Removed harsh active backgrounds; active links only shift `text-muted-foreground → text-foreground`.
- Used `bg-muted/70`, `border-border/40`, `ring-1 ring-border/10`, and `backdrop-blur-2xl` for a softer, glassy surface instead of a solid white bar.
- Kept the logo + `Home / About / Features` links and the `/#features` anchor.
- Mobile menu stays in a shadcn/ui `Sheet`, now with rounded, blurred styling.
- Fixed `next-themes` v0.4 + Tailwind v4 dark-mode mismatch by setting `ThemeProvider attribute="class"`.
- Added `pt-20` to the external layout so content clears the floating navbar.

## Verification

- `pnpm --filter=web typecheck`, `lint`, and `build` all pass.
- Checked desktop light/dark, `/#features` scroll, active link state, and mobile `Sheet`.

Light mode:

![Navbar light](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctODI3MjYwMDJmZjg0NDczN2E3YWZjZDA4Mzc4ZWJhOTAiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctODI3MjYwMDJmZjg0NDczN2E3YWZjZDA4Mzc4ZWJhOTAvODBiZGZkYTItNzNjNC00NDA4LWE0ODQtZGJkN2I1ZTQxMzBlIiwiaWF0IjoxNzg2OTEzNjE4LCJleHAiOjE3ODc1MTg0MTgsImZpbGVuYW1lIjoic3NfMzQ1YTIzODQucG5nIn0.4L2hJdMFDOyV0cMA8ME1s_LL1DP3B-e9W3lR9cLLUuc)

Dark mode:

![Navbar dark](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctODI3MjYwMDJmZjg0NDczN2E3YWZjZDA4Mzc4ZWJhOTAiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctODI3MjYwMDJmZjg0NDczN2E3YWZjZDA4Mzc4ZWJhOTAvNmJiZDBiYzMtMmJjMS00NzA0LWI0OGYtODdjMDhmMTZhY2ZmIiwiaWF0IjoxNzg2OTEzNjE4LCJleHAiOjE3ODc1MTg0MTgsImZpbGVuYW1lIjoic3NfOGMwZjc2NDAucG5nIn0.-V3UfeUQzVIH6HWtAUc_2I7nH3a8wkwsOnrAqTCdCws)

Link to Devin session: https://app.devin.ai/sessions/ab58cc800152494895e00d990a24d9b0
Requested by: @[REDACTED SECRET]